### PR TITLE
Replace deprecated release actions with softprops/action-gh-release

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -92,13 +92,34 @@ jobs:
           } catch (e) {
             console.log(e)
           }
+    # generate release artifacts
+    - name: "Generate release package: buildoor_snapshot_windows_amd64.zip"
+      run: |
+        cd buildoor_windows_amd64
+        zip -r -q ../buildoor_snapshot_windows_amd64.zip .
+    - name: "Generate release package: buildoor_snapshot_linux_amd64.tar.gz"
+      run: |
+        cd buildoor_linux_amd64
+        tar -czf ../buildoor_snapshot_linux_amd64.tar.gz .
+    - name: "Generate release package: buildoor_snapshot_linux_arm64.tar.gz"
+      run: |
+        cd buildoor_linux_arm64
+        tar -czf ../buildoor_snapshot_linux_arm64.tar.gz .
+    - name: "Generate release package: buildoor_snapshot_darwin_amd64.tar.gz"
+      run: |
+        cd buildoor_darwin_amd64
+        tar -czf ../buildoor_snapshot_darwin_amd64.tar.gz .
+    - name: "Generate release package: buildoor_snapshot_darwin_arm64.tar.gz"
+      run: |
+        cd buildoor_darwin_arm64
+        tar -czf ../buildoor_snapshot_darwin_arm64.tar.gz .
+
     - name: Create snapshot release
-      uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1.1.4
-      id: create_release
+      uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
       with:
         draft: false
         prerelease: true
-        release_name: "Dev Snapshot"
+        name: "Dev Snapshot"
         tag_name: "snapshot"
         body: |
           ## Latest automatically built executables. (Unstable development snapshot)
@@ -114,76 +135,9 @@ jobs:
           | [buildoor_snapshot_linux_arm64.tar.gz](https://github.com/ethpandaops/buildoor/releases/download/snapshot/buildoor_snapshot_linux_arm64.tar.gz) | buildoor executables for linux/arm64 |
           | [buildoor_snapshot_darwin_amd64.tar.gz](https://github.com/ethpandaops/buildoor/releases/download/snapshot/buildoor_snapshot_darwin_amd64.tar.gz) | buildoor executable for macos/amd64 |
           | [buildoor_snapshot_darwin_arm64.tar.gz](https://github.com/ethpandaops/buildoor/releases/download/snapshot/buildoor_snapshot_darwin_arm64.tar.gz) | buildoor executable for macos/arm64 |
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-
-    # generate & upload release artifacts
-    - name: "Generate release package: buildoor_snapshot_windows_amd64.zip"
-      run: |
-        cd buildoor_windows_amd64
-        zip -r -q ../buildoor_snapshot_windows_amd64.zip .
-    - name: "Upload snapshot release artifact: buildoor_snapshot_windows_amd64.zip"
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./buildoor_snapshot_windows_amd64.zip
-        asset_name: buildoor_snapshot_windows_amd64.zip
-        asset_content_type: application/octet-stream
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-    
-    - name: "Generate release package: buildoor_snapshot_linux_amd64.tar.gz"
-      run: |
-        cd buildoor_linux_amd64
-        tar -czf ../buildoor_snapshot_linux_amd64.tar.gz .
-    - name: "Upload snapshot release artifact: buildoor_snapshot_linux_amd64.tar.gz"
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./buildoor_snapshot_linux_amd64.tar.gz
-        asset_name: buildoor_snapshot_linux_amd64.tar.gz
-        asset_content_type: application/octet-stream
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-    
-    - name: "Generate release package: buildoor_snapshot_linux_arm64.tar.gz"
-      run: |
-        cd buildoor_linux_arm64
-        tar -czf ../buildoor_snapshot_linux_arm64.tar.gz .
-    - name: "Upload snapshot release artifact: buildoor_snapshot_linux_arm64.tar.gz"
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./buildoor_snapshot_linux_arm64.tar.gz
-        asset_name: buildoor_snapshot_linux_arm64.tar.gz
-        asset_content_type: application/octet-stream
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-    
-    - name: "Generate release package: buildoor_snapshot_darwin_amd64.tar.gz"
-      run: |
-        cd buildoor_darwin_amd64
-        tar -czf ../buildoor_snapshot_darwin_amd64.tar.gz .
-    - name: "Upload snapshot release artifact: buildoor_snapshot_darwin_amd64.tar.gz"
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./buildoor_snapshot_darwin_amd64.tar.gz
-        asset_name: buildoor_snapshot_darwin_amd64.tar.gz
-        asset_content_type: application/octet-stream
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-
-    - name: "Generate release package: buildoor_snapshot_darwin_arm64.tar.gz"
-      run: |
-        cd buildoor_darwin_arm64
-        tar -czf ../buildoor_snapshot_darwin_arm64.tar.gz .
-    - name: "Upload snapshot release artifact: buildoor_snapshot_darwin_arm64.tar.gz"
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./buildoor_snapshot_darwin_arm64.tar.gz
-        asset_name: buildoor_snapshot_darwin_arm64.tar.gz
-        asset_content_type: application/octet-stream
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
+        files: |
+          buildoor_snapshot_windows_amd64.zip
+          buildoor_snapshot_linux_amd64.tar.gz
+          buildoor_snapshot_linux_arm64.tar.gz
+          buildoor_snapshot_darwin_amd64.tar.gz
+          buildoor_snapshot_darwin_arm64.tar.gz

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -65,14 +65,35 @@ jobs:
     - name: "Download build artifacts"
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
 
-    # create draft release
+    # generate release artifacts
+    - name: "Generate release package: buildoor_${{ inputs.version }}_windows_amd64.zip"
+      run: |
+        cd buildoor_windows_amd64
+        zip -r -q ../buildoor_${{ inputs.version }}_windows_amd64.zip .
+    - name: "Generate release package: buildoor_${{ inputs.version }}_linux_amd64.tar.gz"
+      run: |
+        cd buildoor_linux_amd64
+        tar -czf ../buildoor_${{ inputs.version }}_linux_amd64.tar.gz .
+    - name: "Generate release package: buildoor_${{ inputs.version }}_linux_arm64.tar.gz"
+      run: |
+        cd buildoor_linux_arm64
+        tar -czf ../buildoor_${{ inputs.version }}_linux_arm64.tar.gz .
+    - name: "Generate release package: buildoor_${{ inputs.version }}_darwin_amd64.tar.gz"
+      run: |
+        cd buildoor_darwin_amd64
+        tar -czf ../buildoor_${{ inputs.version }}_darwin_amd64.tar.gz .
+    - name: "Generate release package: buildoor_${{ inputs.version }}_darwin_arm64.tar.gz"
+      run: |
+        cd buildoor_darwin_arm64
+        tar -czf ../buildoor_${{ inputs.version }}_darwin_arm64.tar.gz .
+
+    # create release with all artifacts
     - name: Create latest release
-      uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1.1.4
-      id: create_release
+      uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
       with:
         draft: false
         prerelease: false
-        release_name: "v${{ inputs.version }}"
+        name: "v${{ inputs.version }}"
         tag_name: "v${{ inputs.version }}"
         body: |
           ### Major Changes
@@ -94,76 +115,9 @@ jobs:
           | [buildoor_${{ inputs.version }}_linux_arm64.tar.gz](https://github.com/ethpandaops/buildoor/releases/download/v${{ inputs.version }}/buildoor_${{ inputs.version }}_linux_arm64.tar.gz) | buildoor executables for linux/arm64 |
           | [buildoor_${{ inputs.version }}_darwin_amd64.tar.gz](https://github.com/ethpandaops/buildoor/releases/download/v${{ inputs.version }}/buildoor_${{ inputs.version }}_darwin_amd64.tar.gz) | buildoor executable for macos/amd64 |
           | [buildoor_${{ inputs.version }}_darwin_arm64.tar.gz](https://github.com/ethpandaops/buildoor/releases/download/v${{ inputs.version }}/buildoor_${{ inputs.version }}_darwin_arm64.tar.gz) | buildoor executable for macos/arm64 |
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-
-    # generate & upload release artifacts
-    - name: "Generate release package: buildoor_${{ inputs.version }}_windows_amd64.zip"
-      run: |
-        cd buildoor_windows_amd64
-        zip -r -q ../buildoor_${{ inputs.version }}_windows_amd64.zip .
-    - name: "Upload release artifact: buildoor_${{ inputs.version }}_windows_amd64.zip"
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./buildoor_${{ inputs.version }}_windows_amd64.zip
-        asset_name: buildoor_${{ inputs.version }}_windows_amd64.zip
-        asset_content_type: application/octet-stream
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-    
-    - name: "Generate release package: buildoor_${{ inputs.version }}_linux_amd64.tar.gz"
-      run: |
-        cd buildoor_linux_amd64
-        tar -czf ../buildoor_${{ inputs.version }}_linux_amd64.tar.gz .
-    - name: "Upload release artifact: buildoor_${{ inputs.version }}_linux_amd64.tar.gz"
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./buildoor_${{ inputs.version }}_linux_amd64.tar.gz
-        asset_name: buildoor_${{ inputs.version }}_linux_amd64.tar.gz
-        asset_content_type: application/octet-stream
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-    
-    - name: "Generate release package: buildoor_${{ inputs.version }}_linux_arm64.tar.gz"
-      run: |
-        cd buildoor_linux_arm64
-        tar -czf ../buildoor_${{ inputs.version }}_linux_arm64.tar.gz .
-    - name: "Upload release artifact: buildoor_${{ inputs.version }}_linux_arm64.tar.gz"
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./buildoor_${{ inputs.version }}_linux_arm64.tar.gz
-        asset_name: buildoor_${{ inputs.version }}_linux_arm64.tar.gz
-        asset_content_type: application/octet-stream
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-    
-    - name: "Generate release package: buildoor_${{ inputs.version }}_darwin_amd64.tar.gz"
-      run: |
-        cd buildoor_darwin_amd64
-        tar -czf ../buildoor_${{ inputs.version }}_darwin_amd64.tar.gz .
-    - name: "Upload release artifact: buildoor_${{ inputs.version }}_darwin_amd64.tar.gz"
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./buildoor_${{ inputs.version }}_darwin_amd64.tar.gz
-        asset_name: buildoor_${{ inputs.version }}_darwin_amd64.tar.gz
-        asset_content_type: application/octet-stream
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-
-    - name: "Generate release package: buildoor_${{ inputs.version }}_darwin_arm64.tar.gz"
-      run: |
-        cd buildoor_darwin_arm64
-        tar -czf ../buildoor_${{ inputs.version }}_darwin_arm64.tar.gz .
-    - name: "Upload release artifact: buildoor_${{ inputs.version }}_darwin_arm64.tar.gz"
-      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./buildoor_${{ inputs.version }}_darwin_arm64.tar.gz
-        asset_name: buildoor_${{ inputs.version }}_darwin_arm64.tar.gz
-        asset_content_type: application/octet-stream
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
+        files: |
+          buildoor_${{ inputs.version }}_windows_amd64.zip
+          buildoor_${{ inputs.version }}_linux_amd64.tar.gz
+          buildoor_${{ inputs.version }}_linux_arm64.tar.gz
+          buildoor_${{ inputs.version }}_darwin_amd64.tar.gz
+          buildoor_${{ inputs.version }}_darwin_arm64.tar.gz


### PR DESCRIPTION
## Summary
- Replace archived `actions/create-release@v1.1.4` with `softprops/action-gh-release@v2.6.1`
- Remove all `actions/upload-release-asset@v1.0.2` steps, using `softprops/action-gh-release`'s built-in `files` parameter instead
- Fixes `set-output` and Node.js 20 deprecation warnings in both `build-main.yml` and `build-release.yml`

## Test plan
- [ ] Trigger a build on `main` and verify the snapshot release is created with all 5 artifacts attached
- [ ] Trigger a manual release workflow and verify the versioned release is created with all 5 artifacts attached
- [ ] Verify no deprecation warnings appear in the workflow logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)