### PR TITLE
fix: Use head block hash from payload attributes

### DIFF
--- a/pkg/builder/payload_builder.go
+++ b/pkg/builder/payload_builder.go
@@ -117,7 +117,7 @@ func (b *PayloadBuilder) BuildPayloadFromAttributes(
 	// parent_block_hash from payload_attributes is the execution layer parent
 	// TODO - bharath - the head block hash should be attrs.ParentBlockHash, i think there is an
 	// issue in the way I implemented payload attributes for prysm
-	headBlockHash := common.BytesToHash(finalityInfo.HeadExecutionBlockHash[:])
+	headBlockHash := common.BytesToHash(attrs.ParentBlockHash[:])
 	safeBlockHash := common.BytesToHash(finalityInfo.SafeExecutionBlockHash[:])
 	finalizedBlockHash := common.BytesToHash(finalityInfo.FinalizedExecutionBlockHash[:])
 	parentBeaconRoot := common.BytesToHash(attrs.ParentBeaconBlockRoot[:])

--- a/pkg/builder/payload_builder.go
+++ b/pkg/builder/payload_builder.go
@@ -115,8 +115,6 @@ func (b *PayloadBuilder) BuildPayloadFromAttributes(
 
 	// Convert hashes for engine API
 	// parent_block_hash from payload_attributes is the execution layer parent
-	// TODO - bharath - the head block hash should be attrs.ParentBlockHash, i think there is an
-	// issue in the way I implemented payload attributes for prysm
 	headBlockHash := common.BytesToHash(attrs.ParentBlockHash[:])
 	safeBlockHash := common.BytesToHash(finalityInfo.SafeExecutionBlockHash[:])
 	finalizedBlockHash := common.BytesToHash(finalityInfo.FinalizedExecutionBlockHash[:])


### PR DESCRIPTION
We were using the headBlockHash by querying the finalized info from the beacon api as there was some bug in the payload attributes. 
I have found the bug in the payload attributes in the prysm fork where we were using the pre-envelope state instead of the post envelope state to generate the attributes. 