### PR TITLE
ci: drop macos/amd64 release builds

### DIFF
--- a/.github/workflows/_shared-build.yaml
+++ b/.github/workflows/_shared-build.yaml
@@ -200,47 +200,6 @@ jobs:
         path: ./bin/*
         name: buildoor_windows_amd64
 
-  build_darwin_amd64_binary:
-    name: Build macos/amd64 binary
-    needs: [build_ui_package]
-    runs-on: macos-15-intel
-    steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        ref: ${{ inputs.ref }}
-
-    # setup global dependencies
-    - name: Set up go
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-      with:
-        go-version: 1.25.x
-
-    # setup project dependencies
-    - name: Get dependencies
-      run: |
-        go get -v -t -d ./...
-
-    # download UI build artifacts
-    - name: Download UI build artifacts
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-      with:
-        name: webui-package
-        path: ./pkg/webui/static
-
-    # build binaries
-    - name: Build macos amd64 binary
-      run: |
-        make build
-      env:
-        RELEASE: ${{ inputs.release }}
-
-    # upload artifacts
-    - name: "Upload artifact: buildoor_darwin_amd64"
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-      with:
-        path: ./bin/*
-        name: buildoor_darwin_amd64
-
   build_darwin_arm64_binary:
     name: Build macos/arm64 binary
     needs: [build_ui_package]

--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -105,10 +105,6 @@ jobs:
       run: |
         cd buildoor_linux_arm64
         tar -czf ../buildoor_snapshot_linux_arm64.tar.gz .
-    - name: "Generate release package: buildoor_snapshot_darwin_amd64.tar.gz"
-      run: |
-        cd buildoor_darwin_amd64
-        tar -czf ../buildoor_snapshot_darwin_amd64.tar.gz .
     - name: "Generate release package: buildoor_snapshot_darwin_arm64.tar.gz"
       run: |
         cd buildoor_darwin_arm64
@@ -133,11 +129,9 @@ jobs:
           | [buildoor_snapshot_windows_amd64.zip](https://github.com/ethpandaops/buildoor/releases/download/snapshot/buildoor_snapshot_windows_amd64.zip) | buildoor executables for windows/amd64 |
           | [buildoor_snapshot_linux_amd64.tar.gz](https://github.com/ethpandaops/buildoor/releases/download/snapshot/buildoor_snapshot_linux_amd64.tar.gz) | buildoor executables for linux/amd64 |
           | [buildoor_snapshot_linux_arm64.tar.gz](https://github.com/ethpandaops/buildoor/releases/download/snapshot/buildoor_snapshot_linux_arm64.tar.gz) | buildoor executables for linux/arm64 |
-          | [buildoor_snapshot_darwin_amd64.tar.gz](https://github.com/ethpandaops/buildoor/releases/download/snapshot/buildoor_snapshot_darwin_amd64.tar.gz) | buildoor executable for macos/amd64 |
           | [buildoor_snapshot_darwin_arm64.tar.gz](https://github.com/ethpandaops/buildoor/releases/download/snapshot/buildoor_snapshot_darwin_arm64.tar.gz) | buildoor executable for macos/arm64 |
         files: |
           buildoor_snapshot_windows_amd64.zip
           buildoor_snapshot_linux_amd64.tar.gz
           buildoor_snapshot_linux_arm64.tar.gz
-          buildoor_snapshot_darwin_amd64.tar.gz
           buildoor_snapshot_darwin_arm64.tar.gz

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -78,10 +78,6 @@ jobs:
       run: |
         cd buildoor_linux_arm64
         tar -czf ../buildoor_${{ inputs.version }}_linux_arm64.tar.gz .
-    - name: "Generate release package: buildoor_${{ inputs.version }}_darwin_amd64.tar.gz"
-      run: |
-        cd buildoor_darwin_amd64
-        tar -czf ../buildoor_${{ inputs.version }}_darwin_amd64.tar.gz .
     - name: "Generate release package: buildoor_${{ inputs.version }}_darwin_arm64.tar.gz"
       run: |
         cd buildoor_darwin_arm64
@@ -113,11 +109,9 @@ jobs:
           | [buildoor_${{ inputs.version }}_windows_amd64.zip](https://github.com/ethpandaops/buildoor/releases/download/v${{ inputs.version }}/buildoor_${{ inputs.version }}_windows_amd64.zip) | buildoor executables for windows/amd64 |
           | [buildoor_${{ inputs.version }}_linux_amd64.tar.gz](https://github.com/ethpandaops/buildoor/releases/download/v${{ inputs.version }}/buildoor_${{ inputs.version }}_linux_amd64.tar.gz) | buildoor executables for linux/amd64 |
           | [buildoor_${{ inputs.version }}_linux_arm64.tar.gz](https://github.com/ethpandaops/buildoor/releases/download/v${{ inputs.version }}/buildoor_${{ inputs.version }}_linux_arm64.tar.gz) | buildoor executables for linux/arm64 |
-          | [buildoor_${{ inputs.version }}_darwin_amd64.tar.gz](https://github.com/ethpandaops/buildoor/releases/download/v${{ inputs.version }}/buildoor_${{ inputs.version }}_darwin_amd64.tar.gz) | buildoor executable for macos/amd64 |
           | [buildoor_${{ inputs.version }}_darwin_arm64.tar.gz](https://github.com/ethpandaops/buildoor/releases/download/v${{ inputs.version }}/buildoor_${{ inputs.version }}_darwin_arm64.tar.gz) | buildoor executable for macos/arm64 |
         files: |
           buildoor_${{ inputs.version }}_windows_amd64.zip
           buildoor_${{ inputs.version }}_linux_amd64.tar.gz
           buildoor_${{ inputs.version }}_linux_arm64.tar.gz
-          buildoor_${{ inputs.version }}_darwin_amd64.tar.gz
           buildoor_${{ inputs.version }}_darwin_arm64.tar.gz


### PR DESCRIPTION
## Summary
- Remove the `build_darwin_amd64_binary` job from the shared build workflow
- Drop the darwin_amd64 tarball steps, release-notes table row, and files entry from snapshot/release workflows
- Mac builds are now arm64-only

## Test plan
- [ ] Trigger snapshot build and confirm artifacts contain only windows_amd64, linux_amd64, linux_arm64, darwin_arm64
- [ ] On the next tagged release, confirm artifacts and release-notes table match