### PR TITLE
feat: send target gas limit in FCU call

### DIFF
--- a/pkg/builder/payload_builder.go
+++ b/pkg/builder/payload_builder.go
@@ -127,18 +127,23 @@ func (b *PayloadBuilder) BuildPayloadFromAttributes(
 	// Pre-Gloas:  use validator registrations (fee_recipient from the proposer's registerValidator message).
 	// Fallback:   use the builder's configured fee recipient.
 	proposerFeeRecipient := b.feeRecipient
+	var targetGasLimit uint64
 
 	if b.isGloas != nil && b.isGloas() {
 		// Gloas: prefer proposer preferences from cache, fall back to payload_attributes suggested fee recipient.
 		if b.propPrefCache != nil {
 			if prefs, ok := b.propPrefCache.Get(attrs.ProposalSlot); ok && prefs.Message != nil {
 				proposerFeeRecipient = common.Address(prefs.Message.FeeRecipient)
+				targetGasLimit = prefs.Message.GasLimit
 				b.log.WithFields(logrus.Fields{
 					"proposer_index": attrs.ProposerIndex,
 					"fee_recipient":  proposerFeeRecipient.Hex(),
 					"gas_limit":      prefs.Message.GasLimit,
 				}).Debug("Using fee recipient and gas limit from proposer preferences")
 			}
+		}
+		if targetGasLimit == 0 {
+			targetGasLimit = attrs.TargetGasLimit
 		}
 
 		// If we still have the default fee recipient, use SuggestedFeeRecipient from payload_attributes.
@@ -196,6 +201,7 @@ func (b *PayloadBuilder) BuildPayloadFromAttributes(
 			Withdrawals:           engineWithdrawals,
 			ParentBeaconBlockRoot: &parentBeaconRoot,
 			SlotNumber:            uint64(attrs.ProposalSlot),
+			TargetGasLimit:        targetGasLimit,
 		},
 	)
 	if err != nil {

--- a/pkg/rpc/beacon/events.go
+++ b/pkg/rpc/beacon/events.go
@@ -83,6 +83,7 @@ type PayloadAttributesEvent struct {
 	SuggestedFeeRecipient common.Address
 	Withdrawals           []*capella.Withdrawal
 	ParentBeaconBlockRoot phase0.Root
+	TargetGasLimit        uint64
 }
 
 // payloadAttributesEventJSON is used for JSON unmarshaling of payload_attributes events.
@@ -105,6 +106,7 @@ type payloadAttributesEventJSON struct {
 				Amount         string `json:"amount"`
 			} `json:"withdrawals"`
 			ParentBeaconBlockRoot string `json:"parent_beacon_block_root"`
+			TargetGasLimit        string `json:"target_gas_limit"`
 		} `json:"payload_attributes"`
 	} `json:"data"`
 }
@@ -747,6 +749,8 @@ func parsePayloadAttributesEvent(raw *payloadAttributesEventJSON) (*PayloadAttri
 		return nil, fmt.Errorf("invalid parent_beacon_block_root: %w", err)
 	}
 
+	targetGasLimit, _ := strconv.ParseUint(raw.Data.PayloadAttributes.TargetGasLimit, 10, 64)
+
 	// Parse withdrawals
 	withdrawals := make([]*capella.Withdrawal, len(raw.Data.PayloadAttributes.Withdrawals))
 	for i, w := range raw.Data.PayloadAttributes.Withdrawals {
@@ -780,6 +784,7 @@ func parsePayloadAttributesEvent(raw *payloadAttributesEventJSON) (*PayloadAttri
 		SuggestedFeeRecipient: common.HexToAddress(raw.Data.PayloadAttributes.SuggestedFeeRecipient),
 		Withdrawals:           withdrawals,
 		ParentBeaconBlockRoot: parentBeaconBlockRoot,
+		TargetGasLimit:        targetGasLimit,
 	}, nil
 }
 

--- a/pkg/rpc/engine/client.go
+++ b/pkg/rpc/engine/client.go
@@ -54,6 +54,7 @@ type PayloadAttributes struct {
 	Withdrawals           []*types.Withdrawal
 	ParentBeaconBlockRoot *common.Hash
 	SlotNumber            uint64 // Amsterdam (PayloadAttributesV4); zero before activation
+	TargetGasLimit        uint64 // Amsterdam (PayloadAttributesV4); zero before activation
 }
 
 // ExecutionPayload represents an execution layer payload (typed, with JSON marshal/unmarshal for API).
@@ -462,6 +463,7 @@ func (c *Client) RequestPayloadBuild(
 	attrsV4 := make(map[string]any, len(attrsMap)+1)
 	maps.Copy(attrsV4, attrsMap)
 	attrsV4["slotNumber"] = fmt.Sprintf("0x%x", attrs.SlotNumber)
+	attrsV4["targetGasLimit"] = fmt.Sprintf("0x%x", attrs.TargetGasLimit)
 
 	c.log.WithFields(logrus.Fields{
 		"attrs_map": attrsV4,
@@ -475,6 +477,7 @@ func (c *Client) RequestPayloadBuild(
 		"withdrawals":              len(attrs.Withdrawals),
 		"parent_beacon_block_root": attrs.ParentBeaconBlockRoot.Hex(),
 		"slot_number":              attrs.SlotNumber,
+		"target_gas_limit":         attrs.TargetGasLimit,
 	}).Info("Payload attributes being sent to forkchoiceUpdated")
 
 	var response ForkchoiceUpdatedResponse


### PR DESCRIPTION
The CL now dictates the gas limit The gas limit is passed to the FCU call as specified here: https://github.com/ethereum/execution-apis/pull/796