### PR TITLE
webui: hide edit buttons when logged out, fix mobile nav menu

### DIFF
--- a/pkg/webui/src/components/BrandHeader.tsx
+++ b/pkg/webui/src/components/BrandHeader.tsx
@@ -8,6 +8,18 @@ const THEME_ICONS: Record<ThemeMode, string> = {
   auto: '#circle-half',
 };
 
+// Close the expanded mobile hamburger menu. Bootstrap's collapse data-API
+// keys off the `show` class, so clearing it directly keeps the toggler in
+// sync for the next tap.
+export function closeMobileNav(): void {
+  const collapse = document.getElementById('navbarSupportedContent');
+  if (!collapse?.classList.contains('show')) return;
+  collapse.classList.remove('show');
+  const toggler = document.querySelector('.navbar-toggler');
+  toggler?.classList.add('collapsed');
+  toggler?.setAttribute('aria-expanded', 'false');
+}
+
 interface BrandHeaderProps {
   title: string;
   brandHref?: string;
@@ -28,6 +40,7 @@ export const BrandHeader: React.FC<BrandHeaderProps> = ({
   const handleBrand = onBrandClick
     ? (e: React.MouseEvent<HTMLAnchorElement>) => {
         e.preventDefault();
+        closeMobileNav();
         onBrandClick();
       }
     : undefined;
@@ -124,7 +137,7 @@ export const BrandHeader: React.FC<BrandHeaderProps> = ({
               </li>
 
               {endContent && (
-                <li className="nav-item ms-3 d-flex align-items-center">{endContent}</li>
+                <li className="nav-item ms-lg-3 mt-2 mt-lg-0 d-flex align-items-center">{endContent}</li>
               )}
             </ul>
           </div>

--- a/pkg/webui/src/components/BuilderAPIConfigPanel.tsx
+++ b/pkg/webui/src/components/BuilderAPIConfigPanel.tsx
@@ -151,9 +151,11 @@ export const BuilderAPIConfigPanel: React.FC<BuilderAPIConfigPanelProps> = ({ st
                 <>
                   <div className="d-flex justify-content-between align-items-center mb-1">
                     <div className="section-header">Configuration</div>
-                    <button className="btn btn-sm btn-outline-primary" onClick={(e) => { e.stopPropagation(); startEditing(); }}>
-                      <i className="fas fa-pencil-alt"></i>
-                    </button>
+                    {isLoggedIn && (
+                      <button className="btn btn-sm btn-outline-primary" onClick={(e) => { e.stopPropagation(); startEditing(); }}>
+                        <i className="fas fa-pencil-alt"></i>
+                      </button>
+                    )}
                   </div>
                   <div className="row g-2">
                     <div className="col-6">

--- a/pkg/webui/src/components/BuilderConfigPanel.tsx
+++ b/pkg/webui/src/components/BuilderConfigPanel.tsx
@@ -120,12 +120,10 @@ export const BuilderConfigPanel: React.FC<BuilderConfigPanelProps> = ({ config }
           {/* Build Config Section */}
           <div className="d-flex justify-content-between align-items-center mb-2">
             <div className="section-header">Build Config</div>
-            {!editing && (
+            {canEdit && !editing && (
               <button
                 className="btn btn-sm btn-outline-primary"
                 onClick={() => setEditing(true)}
-                disabled={!canEdit}
-                title={!canEdit ? 'Login required to edit' : ''}
               >
                 <i className="fas fa-pencil-alt"></i>
               </button>
@@ -181,12 +179,10 @@ export const BuilderConfigPanel: React.FC<BuilderConfigPanelProps> = ({ config }
           {/* Schedule Section */}
           <div className="d-flex justify-content-between align-items-center mb-2">
             <div className="section-header">Schedule</div>
-            {!editingSchedule && (
+            {canEdit && !editingSchedule && (
               <button
                 className="btn btn-sm btn-outline-primary"
                 onClick={() => setEditingSchedule(true)}
-                disabled={!canEdit}
-                title={!canEdit ? 'Login required to edit' : ''}
               >
                 <i className="fas fa-pencil-alt"></i>
               </button>

--- a/pkg/webui/src/components/ConfigPanel.tsx
+++ b/pkg/webui/src/components/ConfigPanel.tsx
@@ -145,12 +145,10 @@ export const ConfigPanel: React.FC<ConfigPanelProps> = ({ config, serviceStatus 
           {/* Timing Config Section */}
           <div className="d-flex justify-content-between align-items-center mb-2">
             <div className="section-header">Timing Config</div>
-            {!editingTiming && (
+            {canEdit && !editingTiming && (
               <button
                 className="btn btn-sm btn-outline-primary"
                 onClick={() => setEditingTiming(true)}
-                disabled={!canEdit}
-                title={!canEdit ? 'Login required to edit' : ''}
               >
                 <i className="fas fa-pencil-alt"></i>
               </button>

--- a/pkg/webui/src/components/HeaderNav.tsx
+++ b/pkg/webui/src/components/HeaderNav.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { getViewPath, setView, useView, type ViewType } from '../stores/viewStore';
 import { getRuntimeConfig } from '../utils/runtimeConfig';
+import { closeMobileNav } from './BrandHeader';
 
 const NAV_ITEMS: Array<{ view: ViewType; label: string }> = [
   { view: 'dashboard', label: 'Dashboard' },
@@ -32,6 +33,7 @@ export const HeaderNav: React.FC = () => {
             className={`nav-link header-nav-button ${currentView === item.view ? 'active' : ''}`}
             onClick={(e) => {
               e.preventDefault();
+              closeMobileNav();
               setView(item.view);
             }}
           >

--- a/pkg/webui/src/styles.css
+++ b/pkg/webui/src/styles.css
@@ -731,6 +731,29 @@ header.header-bar .navbar {
   }
 }
 
+/* Mobile: the header is fixed at 65px, so the expanded hamburger menu
+   overflows it. Render the menu as a solid panel anchored below the
+   header instead of letting nav items float over the page content. */
+@media (max-width: 991.98px) {
+  header.header-bar .navbar-collapse {
+    position: absolute;
+    top: 65px;
+    left: 0;
+    right: 0;
+    background-color: var(--bs-dark);
+    border-top: 1px solid rgba(255, 255, 255, 0.1);
+    box-shadow: 0 0.5em 1em rgba(0, 0, 0, 0.35);
+    padding: 0.5rem 1rem 1rem;
+    max-height: calc(100vh - 65px);
+    overflow-y: auto;
+  }
+
+  header.header-bar .navbar-collapse .nav-link {
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+  }
+}
+
 .colormode-icon {
   width: 1em;
   height: 1em;


### PR DESCRIPTION
## Summary
- Hide config edit (pencil) buttons from non-logged-in users instead of rendering them disabled (`ConfigPanel`, `BuilderConfigPanel`). Also gates the Builder API subsidy pencil in `BuilderAPIConfigPanel`, which was previously shown to everyone and let anonymous users open the edit form. Open mode (no `--auth-provider-url`) is unaffected since it's treated as logged in.
- Fix the mobile hamburger menu: the header is `position: fixed` with a hard 65px height, so the expanded menu items overflowed below it and floated transparently over the page content. The expanded menu is now a solid dark panel anchored under the header, with a top border, shadow, larger tap targets, and max-height scrolling.
- Collapse the mobile menu when a nav item or the brand is clicked — since this is an SPA, the open menu previously stayed covering the newly selected view.
- Stack the login/user display cleanly in the mobile panel (`ms-lg-3` instead of `ms-3`).

## Test plan
- `npm run build` in `pkg/webui` compiles cleanly
- Run with `--api-port 8082`, open the dashboard in a narrow viewport: hamburger menu opens as a readable dark panel, closes on nav item tap
- With an auth provider configured and logged out: no pencil/edit buttons visible on ePBS Bidder, Payload Builder, or Builder API panels; after login they appear