### PR TITLE
lifecycle: estimate builder deposit/exit gas instead of hardcoding

### DIFF
--- a/pkg/lifecycle/deposit.go
+++ b/pkg/lifecycle/deposit.go
@@ -31,9 +31,6 @@ func isDepositDeferred(err error) bool {
 	return errors.Is(err, ErrDepositFeeTooHigh) || errors.Is(err, ErrContractNotActive)
 }
 
-// depositGasLimit is the gas limit for builder deposit transactions.
-const depositGasLimit = 800000
-
 // DepositService handles builder deposits and top-ups via the EIP-8282 builder
 // deposit system contract.
 type DepositService struct {
@@ -184,16 +181,20 @@ func (s *DepositService) resolveDepositFee(ctx context.Context) (*big.Int, error
 }
 
 // sendDepositTransaction sends the deposit transaction to the builder deposit contract.
-//
-// SendAndConfirm sources a fresh nonce and resolves nonce conflicts/displacement, so
-// several instances can share this funding key safely.
+// Gas is estimated per-transaction so it tracks the active fork's gas schedule rather
+// than a hardcoded limit that goes stale and reverts out-of-gas.
 func (s *DepositService) sendDepositTransaction(ctx context.Context, calldata []byte, value *big.Int) error {
+	gasLimit, err := s.wallet.EstimateGas(ctx, BuilderDepositContractAddress, value, calldata)
+	if err != nil {
+		return fmt.Errorf("failed to estimate deposit gas: %w", err)
+	}
+
 	receipt, err := s.wallet.SendAndConfirm(
 		ctx,
 		BuilderDepositContractAddress,
 		value,
 		calldata,
-		depositGasLimit,
+		gasLimit,
 		5*time.Minute,
 	)
 	if err != nil {

--- a/pkg/lifecycle/early_deposit.go
+++ b/pkg/lifecycle/early_deposit.go
@@ -137,7 +137,12 @@ func (s *EarlyDepositService) CreateEarlyDeposit(ctx context.Context, amountGwei
 		"value_wei":        value.String(),
 	}).Info("Early builder deposit prepared (regular deposit contract)")
 
-	receipt, err := s.wallet.SendAndConfirm(ctx, *depositContract, value, calldata, depositGasLimit, 5*time.Minute)
+	gasLimit, err := s.wallet.EstimateGas(ctx, *depositContract, value, calldata)
+	if err != nil {
+		return fmt.Errorf("failed to estimate early deposit gas: %w", err)
+	}
+
+	receipt, err := s.wallet.SendAndConfirm(ctx, *depositContract, value, calldata, gasLimit, 5*time.Minute)
 	if err != nil {
 		return fmt.Errorf("early deposit transaction failed: %w", err)
 	}

--- a/pkg/lifecycle/exit.go
+++ b/pkg/lifecycle/exit.go
@@ -12,9 +12,6 @@ import (
 	"github.com/ethpandaops/buildoor/pkg/wallet"
 )
 
-// exitGasLimit is the gas limit for builder exit transactions.
-const exitGasLimit = 200000
-
 // ExitService handles builder exits via the EIP-8282 builder exit system contract.
 //
 // Unlike a validator voluntary exit (a BLS-signed beacon message), a builder exit is
@@ -71,12 +68,18 @@ func (s *ExitService) CreateExit(ctx context.Context) error {
 
 	s.log.WithField("queue_fee_wei", fee.String()).Info("Builder exit prepared")
 
+	// Estimate gas per-transaction (see sendDepositTransaction).
+	gasLimit, err := s.wallet.EstimateGas(ctx, BuilderExitContractAddress, fee, calldata)
+	if err != nil {
+		return fmt.Errorf("failed to estimate exit gas: %w", err)
+	}
+
 	receipt, err := s.wallet.SendAndConfirm(
 		ctx,
 		BuilderExitContractAddress,
 		fee,
 		calldata,
-		exitGasLimit,
+		gasLimit,
 		5*time.Minute,
 	)
 	if err != nil {

--- a/pkg/wallet/wallet.go
+++ b/pkg/wallet/wallet.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -29,6 +30,13 @@ const (
 	txConflictBackoff = 500 * time.Millisecond
 )
 
+// gasEstimateBuffer scales up an eth_estimateGas result (3/2 = +50%) for headroom.
+// Unused gas is refunded under EIP-1559, so over-estimating is effectively free.
+const (
+	gasEstimateBufferNum = 3
+	gasEstimateBufferDen = 2
+)
+
 // walletBackend is the subset of execution-RPC operations the wallet depends on.
 // It is satisfied by *execution.Client and lets transaction-submission logic be
 // exercised against a fake in tests.
@@ -38,6 +46,7 @@ type walletBackend interface {
 	GetConfirmedNonce(ctx context.Context, address common.Address) (uint64, error)
 	GetBalance(ctx context.Context, address common.Address) (*big.Int, error)
 	SuggestGasTipCap(ctx context.Context) (*big.Int, error)
+	EstimateGas(ctx context.Context, msg ethereum.CallMsg) (uint64, error)
 	HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error)
 	SendTransaction(ctx context.Context, tx *types.Transaction) error
 	GetTransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error)
@@ -134,6 +143,22 @@ func (w *Wallet) GetNonce(ctx context.Context) (uint64, error) {
 	}
 
 	return nonce, nil
+}
+
+// EstimateGas estimates the gas for a call from this wallet, scaled by gasEstimateBuffer.
+// value is included because the builder system contracts gate execution on msg.value.
+func (w *Wallet) EstimateGas(ctx context.Context, to common.Address, value *big.Int, data []byte) (uint64, error) {
+	gas, err := w.rpcClient.EstimateGas(ctx, ethereum.CallMsg{
+		From:  w.address,
+		To:    &to,
+		Value: value,
+		Data:  data,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("failed to estimate gas: %w", err)
+	}
+
+	return gas * gasEstimateBufferNum / gasEstimateBufferDen, nil
 }
 
 // Sync synchronizes the wallet state with the chain.

--- a/pkg/wallet/wallet_test.go
+++ b/pkg/wallet/wallet_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -70,6 +71,10 @@ func (f *fakeBackend) GetBalance(context.Context, common.Address) (*big.Int, err
 
 func (f *fakeBackend) SuggestGasTipCap(context.Context) (*big.Int, error) {
 	return big.NewInt(1_000_000_000), nil
+}
+
+func (f *fakeBackend) EstimateGas(context.Context, ethereum.CallMsg) (uint64, error) {
+	return 21_000, nil
 }
 
 func (f *fakeBackend) HeaderByNumber(context.Context, *big.Int) (*types.Header, error) {


### PR DESCRIPTION
## Problem

Builder deposits on a glamsterdam-devnet-6 enclave fail with:

```
Deposit failed: deposit transaction failed: transaction reverted
Registration attempt failed: failed to create deposit ... retrying in 30s
```

Traced on the live devnet, this is **out-of-gas**, not a contract rejection:

- The deposit reaches the EIP-8282 predeploy and reverts with `status 0`; `debug_traceTransaction` reports `"error": "Out Of Gas"` with `gasUsed == gasLimit == 800000` (a real `REVERT` would refund leftover gas).
- The contract is deployed, active (slot0 excess = 0), and the fee path works; the calldata and `msg.value` are correct — every `require` passes. It's purely the gas ceiling.
- `eth_estimateGas` for the exact call returns **925,088**, above the hardcoded `depositGasLimit = 800000`, so it can never fit.

## Root cause

devnet-6 ships gas-repricing EIPs that hit exactly what a builder deposit does — it writes ~8 fresh storage slots:

| EIP | Change | Old | New |
|-----|--------|-----|-----|
| EIP-8037 | state creation per new slot (64B × CPSB 1530) | 20,000 | 97,920 (~5×) |
| EIP-8038 | `STORAGE_WRITE` | 2,800 | 10,000 |
| EIP-8038 | `COLD_STORAGE_ACCESS` | 2,100 | 3,000 |

So the deposit went from ~210k (old schedule) to ~925k — past the 800k cap. The earlier 400k→800k bump was chasing the same moving target. ethrex meters this correctly (it passes the spec tests); the stale hardcoded limit is the bug, and it'll keep going stale every repricing.

## Fix

Estimate gas per-transaction via `eth_estimateGas` for both deposit and exit, with `msg.value` set (the predeploys gate on it) and a +50% buffer. Unused gas is refunded under EIP-1559, so over-estimating is effectively free, and the limit now tracks whatever the active fork charges. Removes `depositGasLimit` (800k) and `exitGasLimit` (200k) — the latter would have OOM'd under the same repricing too.

## Testing

- `go build ./...`, `go vet`, `go test ./pkg/wallet/... ./pkg/lifecycle/...` pass.
- Verified against the running `glam` enclave: `eth_estimateGas` = 925,088 for the failing deposit; ×1.5 buffer → ~1.39M limit, comfortably above.