### PR TITLE
Pass extra data prefix as a flag

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -65,6 +65,7 @@ func init() {
 	rootCmd.PersistentFlags().Uint64("deposit-amount", defaults.DepositAmount, "Builder deposit amount in Gwei")
 	rootCmd.PersistentFlags().Uint64("topup-threshold", defaults.TopupThreshold, "Balance threshold for auto top-up in Gwei")
 	rootCmd.PersistentFlags().Uint64("topup-amount", defaults.TopupAmount, "Amount to top-up in Gwei")
+	rootCmd.PersistentFlags().String("extra-data", defaults.ExtraData, "Prefix injected into the built payload's extra-data field (padded with the EL's original extra data, truncated to 32 bytes)")
 	rootCmd.PersistentFlags().String("log-level", "info", "Log level (debug, info, warn, error)")
 	rootCmd.PersistentFlags().String("state-db", "", "Optional path to a SQLite state-db. When set, UI setting overrides, won blocks, validator registrations, proposer preferences and an audit log are persisted across restarts. When empty, runtime changes are in-memory only.")
 
@@ -167,6 +168,7 @@ func initConfig() error {
 		DepositAmount:  v.GetUint64("deposit-amount"),
 		TopupThreshold: v.GetUint64("topup-threshold"),
 		TopupAmount:    v.GetUint64("topup-amount"),
+		ExtraData:      v.GetString("extra-data"),
 		Schedule: config.ScheduleConfig{
 			Mode:      config.ScheduleMode(v.GetString("schedule-mode")),
 			EveryNth:  v.GetUint64("schedule-every-nth"),

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -16,6 +16,7 @@ func DefaultConfig() *Config {
 		DepositAmount:  50000000000, // 50 ETH in Gwei
 		TopupThreshold: 10000000000, // 10 ETH in Gwei
 		TopupAmount:    50000000000, // 50 ETH in Gwei
+		ExtraData:      "buildoor/",
 		Schedule: ScheduleConfig{
 			Mode:     ScheduleModeAll,
 			EveryNth: 1,

--- a/pkg/config/settings_fields.go
+++ b/pkg/config/settings_fields.go
@@ -94,6 +94,7 @@ func Fields() []Field {
 		newField(KeyEPBSBidSubsidy, "epbs-bid-subsidy", func(c *Config) *uint64 { return &c.EPBS.BidSubsidy }),
 
 		newField(KeyPayloadBuildTime, "payload-build-time", func(c *Config) *uint64 { return &c.PayloadBuildTime }),
+		newField(KeyExtraData, "extra-data", func(c *Config) *string { return &c.ExtraData }),
 		newField(KeyBuilderAPISubsidy, "builder-api-subsidy", func(c *Config) *uint64 { return &c.BuilderAPI.BlockValueSubsidyGwei }),
 
 		newField(KeyDepositAmount, "deposit-amount", func(c *Config) *uint64 { return &c.DepositAmount }),

--- a/pkg/config/settings_keys.go
+++ b/pkg/config/settings_keys.go
@@ -19,6 +19,7 @@ const (
 	KeyEPBSBidSubsidy     = "epbs.bid_subsidy"
 
 	KeyPayloadBuildTime  = "payload_build_time"
+	KeyExtraData         = "extra_data"
 	KeyBuilderAPISubsidy = "builder_api.block_value_subsidy_gwei"
 
 	KeyDepositAmount  = "deposit_amount"

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -22,30 +22,34 @@ type Config struct {
 	// BuilderKeyIndex using the standard validator key path m/12381/3600/{index}/0/0.
 	// Mutually exclusive with BuilderPrivkey. json:"-" keeps the secret out of every JSON
 	// serialization path (WebUI REST + SSE); YAML config loading is unaffected.
-	BuilderMnemonic   string                `yaml:"builder_mnemonic" json:"-"`
-	BuilderKeyIndex   uint64                `yaml:"builder_key_index" json:"builder_key_index"`
-	CLClient          string                `yaml:"cl_client" json:"cl_client,omitempty"`
-	ELEngineAPI       string                `yaml:"el_engine_api" json:"el_engine_api,omitempty"`   // Engine API URL (required for payload building)
-	ELJWTSecret       string                `yaml:"el_jwt_secret" json:"el_jwt_secret,omitempty"`   // Path to JWT secret file for engine API auth
-	ELRPC             string                `yaml:"el_rpc" json:"el_rpc,omitempty"`                 // Optional: EL JSON-RPC for transactions (lifecycle only)
-	WalletPrivkey     string                `yaml:"wallet_privkey" json:"wallet_privkey,omitempty"` // Optional: only if lifecycle enabled
-	APIPort           int                   `yaml:"api_port" json:"api_port"`                       // Optional, 0 = disabled
-	AuthProviderURL   string                `yaml:"auth_provider_url" json:"auth_provider_url"`     // Optional: authenticatoor URL; when set, API requests must carry a JWT verified against the authenticatoor's JWKS. When empty, the API is unauthenticated.
-	InjectHeadHTML    string                `yaml:"inject_head_html" json:"inject_head_html"`       // Optional: raw HTML snippet (e.g. analytics tags) injected into <head> of the served SPA. Falls back to BUILDOOR_INJECT_HEAD_HTML env var when empty.
-	OverviewURL       string                `yaml:"overview_url" json:"overview_url"`               // Optional: URL of the multi-instance overview UI. When set, the dashboard renders an "Overview" entry in the top nav so operators get consistent navigation across instances.
-	LifecycleEnabled  bool                  `yaml:"lifecycle_enabled" json:"lifecycle_enabled"`
-	EPBSEnabled       bool                  `yaml:"epbs_enabled" json:"epbs_enabled"`               // Initial enabled state for ePBS (service available if Gloas fork is scheduled)
-	BuilderAPIEnabled bool                  `yaml:"builder_api_enabled" json:"builder_api_enabled"` // Initial enabled state for Builder API
-	BuilderAPI        BuilderAPIConfig      `yaml:"builder_api" json:"builder_api"`                 // Builder API configuration
-	DepositAmount     uint64                `yaml:"deposit_amount" json:"deposit_amount"`           // Gwei, default 10 ETH
-	TopupThreshold    uint64                `yaml:"topup_threshold" json:"topup_threshold"`         // Gwei
-	TopupAmount       uint64                `yaml:"topup_amount" json:"topup_amount"`               // Gwei
-	Schedule          ScheduleConfig        `yaml:"schedule" json:"schedule"`
-	EPBS              EPBSConfig            `yaml:"epbs" json:"epbs"` // Time-scheduled ePBS config
-	Debug             bool                  `yaml:"debug" json:"debug"`
-	Pprof             bool                  `yaml:"pprof" json:"pprof"`
-	PayloadBuildTime  uint64                `yaml:"payload_build_time" json:"payload_build_time"` // The time given to the EL to build the payload after triggering the payload build via fcu (in ms)
-	ValidatorRanges   ValidatorRangesConfig `yaml:"validator_ranges" json:"validator_ranges"`
+	BuilderMnemonic   string           `yaml:"builder_mnemonic" json:"-"`
+	BuilderKeyIndex   uint64           `yaml:"builder_key_index" json:"builder_key_index"`
+	CLClient          string           `yaml:"cl_client" json:"cl_client,omitempty"`
+	ELEngineAPI       string           `yaml:"el_engine_api" json:"el_engine_api,omitempty"`   // Engine API URL (required for payload building)
+	ELJWTSecret       string           `yaml:"el_jwt_secret" json:"el_jwt_secret,omitempty"`   // Path to JWT secret file for engine API auth
+	ELRPC             string           `yaml:"el_rpc" json:"el_rpc,omitempty"`                 // Optional: EL JSON-RPC for transactions (lifecycle only)
+	WalletPrivkey     string           `yaml:"wallet_privkey" json:"wallet_privkey,omitempty"` // Optional: only if lifecycle enabled
+	APIPort           int              `yaml:"api_port" json:"api_port"`                       // Optional, 0 = disabled
+	AuthProviderURL   string           `yaml:"auth_provider_url" json:"auth_provider_url"`     // Optional: authenticatoor URL; when set, API requests must carry a JWT verified against the authenticatoor's JWKS. When empty, the API is unauthenticated.
+	InjectHeadHTML    string           `yaml:"inject_head_html" json:"inject_head_html"`       // Optional: raw HTML snippet (e.g. analytics tags) injected into <head> of the served SPA. Falls back to BUILDOOR_INJECT_HEAD_HTML env var when empty.
+	OverviewURL       string           `yaml:"overview_url" json:"overview_url"`               // Optional: URL of the multi-instance overview UI. When set, the dashboard renders an "Overview" entry in the top nav so operators get consistent navigation across instances.
+	LifecycleEnabled  bool             `yaml:"lifecycle_enabled" json:"lifecycle_enabled"`
+	EPBSEnabled       bool             `yaml:"epbs_enabled" json:"epbs_enabled"`               // Initial enabled state for ePBS (service available if Gloas fork is scheduled)
+	BuilderAPIEnabled bool             `yaml:"builder_api_enabled" json:"builder_api_enabled"` // Initial enabled state for Builder API
+	BuilderAPI        BuilderAPIConfig `yaml:"builder_api" json:"builder_api"`                 // Builder API configuration
+	DepositAmount     uint64           `yaml:"deposit_amount" json:"deposit_amount"`           // Gwei, default 10 ETH
+	TopupThreshold    uint64           `yaml:"topup_threshold" json:"topup_threshold"`         // Gwei
+	TopupAmount       uint64           `yaml:"topup_amount" json:"topup_amount"`               // Gwei
+	Schedule          ScheduleConfig   `yaml:"schedule" json:"schedule"`
+	EPBS              EPBSConfig       `yaml:"epbs" json:"epbs"` // Time-scheduled ePBS config
+	Debug             bool             `yaml:"debug" json:"debug"`
+	Pprof             bool             `yaml:"pprof" json:"pprof"`
+	PayloadBuildTime  uint64           `yaml:"payload_build_time" json:"payload_build_time"` // The time given to the EL to build the payload after triggering the payload build via fcu (in ms)
+	// ExtraData is the prefix injected into the built payload's extra-data field
+	// (then padded with the EL's original extra data, truncated to 32 bytes). Used
+	// to mark blocks built by this builder. Defaulted to "buildoor/" when empty.
+	ExtraData       string                `yaml:"extra_data" json:"extra_data"`
+	ValidatorRanges ValidatorRangesConfig `yaml:"validator_ranges" json:"validator_ranges"`
 	// StateDBPath, when set, enables the optional SQLite state-db at this path.
 	// It persists UI setting overrides, won blocks, validator registrations,
 	// proposer preferences and an audit log across restarts. Startup-only and

--- a/pkg/payload_builder/payload_builder.go
+++ b/pkg/payload_builder/payload_builder.go
@@ -267,7 +267,7 @@ func (b *PayloadBuilder) BuildPayloadFromAttributes(
 	newHash, err := ModifyPayloadExtraData(
 		enginePayload,
 		resp.ExecutionRequests,
-		[]byte("buildoor/"),
+		[]byte(b.cfg.ExtraData),
 		common.Hash(attrs.ParentBeaconBlockRoot),
 	)
 	if err != nil {

--- a/pkg/payload_builder/payload_modifier.go
+++ b/pkg/payload_builder/payload_modifier.go
@@ -70,9 +70,16 @@ func ModifyPayloadExtraData(
 		}
 	}
 
-	// Build new extra data: prefix + original (truncated to fit).
+	// Build new extra data: prefix + "/" separator + original (truncated to
+	// fit). The separator keeps the prefix readable when concatenated with the
+	// EL's original extra data (e.g. "buildoor-0/ethrex 17.0.0" rather than
+	// "buildoor-0ethrex 17.0.0").
 	newExtraData := make([]byte, 0, maxExtraDataSize)
 	newExtraData = append(newExtraData, extraDataPrefix...)
+
+	if len(extraDataPrefix) > 0 && len(newExtraData) < maxExtraDataSize {
+		newExtraData = append(newExtraData, '/')
+	}
 
 	if remaining := maxExtraDataSize - len(newExtraData); remaining > 0 && len(header.Extra) > 0 {
 		if len(header.Extra) > remaining {

--- a/pkg/webui/handlers/api/api.go
+++ b/pkg/webui/handlers/api/api.go
@@ -69,8 +69,9 @@ type UpdateEPBSRequest struct {
 
 // UpdateBuilderConfigRequest is the request for updating shared builder config.
 type UpdateBuilderConfigRequest struct {
-	BuildStartTime    *int64 `json:"build_start_time,omitempty"`
-	PayloadBuildDelay *int64 `json:"payload_build_delay,omitempty"`
+	BuildStartTime    *int64  `json:"build_start_time,omitempty"`
+	PayloadBuildDelay *int64  `json:"payload_build_delay,omitempty"`
+	ExtraData         *string `json:"extra_data,omitempty"`
 }
 
 // UpdateBuilderAPIConfigRequest is the request for updating Builder API config.
@@ -612,6 +613,10 @@ func (h *APIHandler) UpdateBuilderConfig(w http.ResponseWriter, r *http.Request)
 
 	if req.PayloadBuildDelay != nil {
 		updates[config.KeyPayloadBuildTime] = mustJSON(uint64(*req.PayloadBuildDelay))
+	}
+
+	if req.ExtraData != nil {
+		updates[config.KeyExtraData] = mustJSON(*req.ExtraData)
 	}
 
 	if !h.applySettings(w, r, token, "config.builder", req, updates) {

--- a/pkg/webui/src/components/BuilderConfigPanel.tsx
+++ b/pkg/webui/src/components/BuilderConfigPanel.tsx
@@ -9,6 +9,7 @@ interface BuilderConfigPanelProps {
 interface BuilderFormState {
   build_start_time: number;
   payload_build_delay: number;
+  extra_data: string;
 }
 
 export const BuilderConfigPanel: React.FC<BuilderConfigPanelProps> = ({ config }) => {
@@ -20,6 +21,7 @@ export const BuilderConfigPanel: React.FC<BuilderConfigPanelProps> = ({ config }
   const [form, setForm] = useState<BuilderFormState>({
     build_start_time: 0,
     payload_build_delay: 0,
+    extra_data: '',
   });
 
   const [scheduleForm, setScheduleForm] = useState<ScheduleConfig>({
@@ -42,6 +44,7 @@ export const BuilderConfigPanel: React.FC<BuilderConfigPanelProps> = ({ config }
       setForm({
         build_start_time: config.epbs.build_start_time || 0,
         payload_build_delay: payloadBuildDelay,
+        extra_data: config.extra_data ?? '',
       });
     }
   }, [config, editing, payloadBuildDelay]);
@@ -144,6 +147,12 @@ export const BuilderConfigPanel: React.FC<BuilderConfigPanelProps> = ({ config }
                   <div className="config-item-value">{payloadBuildDelay} ms</div>
                 </div>
               </div>
+              <div className="col-12">
+                <div className="config-item">
+                  <div className="config-item-label">Extra Data</div>
+                  <div className="config-item-value">{config?.extra_data || '—'}</div>
+                </div>
+              </div>
             </div>
           ) : (
             <form onSubmit={handleSave} className="mb-3">
@@ -166,6 +175,18 @@ export const BuilderConfigPanel: React.FC<BuilderConfigPanelProps> = ({ config }
                   onChange={(e) => setForm({ ...form, payload_build_delay: parseInt(e.target.value) || 0 })}
                   required
                 />
+              </div>
+              <div className="mb-2">
+                <label className="form-label">Extra Data</label>
+                <input
+                  type="text"
+                  className="form-control form-control-sm"
+                  value={form.extra_data}
+                  maxLength={32}
+                  placeholder="buildoor/"
+                  onChange={(e) => setForm({ ...form, extra_data: e.target.value })}
+                />
+                <div className="form-text">Prefix injected into the block's extra-data field (max 32 bytes, padded with the EL's original extra data).</div>
               </div>
               <div className="d-flex gap-2">
                 <button type="submit" className="btn btn-sm btn-primary">Save</button>

--- a/pkg/webui/src/types.ts
+++ b/pkg/webui/src/types.ts
@@ -26,6 +26,8 @@ export interface Config {
   deposit_amount: number;
   topup_threshold: number;
   topup_amount: number;
+  payload_build_time?: number;
+  extra_data?: string;
 }
 
 export interface ScheduleConfig {


### PR DESCRIPTION
Ports the extra-data prefix feature from `glamsterdam-devnet-6` (#115) to `main`. This is a generally useful feature that belongs on `main`, not just the devnet branch.

## What it does

Replaces the hardcoded `"buildoor/"` extra-data prefix with a configurable one:

- New `--extra-data` CLI flag / `extra_data` setting (default `"buildoor/"`).
- Editable live from the WebUI Builder config panel (max 32 bytes).
- `ModifyPayloadExtraData` now appends a `/` separator after the prefix so it stays readable when concatenated with the EL's original extra data (e.g. `buildoor-0/ethrex 17.0.0` rather than `buildoor-0ethrex 17.0.0`), then truncates to 32 bytes.

## Notes

- Applied cleanly onto `main` (the devnet branch had diverged via `DepositMaxFeeGwei`, so this was ported field-by-field rather than cherry-picked, and the gofmt whitespace noise from the original PR was dropped).
- `go build ./...` passes and all touched Go files are gofmt-clean.
- Frontend changes are source-only (`src/`), matching the original PR; the `static/` bundle is not rebuilt here.