### PR TITLE
fix: use a present execution block hash for FCU safe/finalized (ePBS payload availability)

### DIFF
--- a/pkg/rpc/beacon/client.go
+++ b/pkg/rpc/beacon/client.go
@@ -299,8 +299,12 @@ type BlockInfo struct {
 	Slot               phase0.Slot
 	Root               phase0.Root
 	ExecutionBlockHash phase0.Hash32
-	ParentRoot         phase0.Root
-	StateRoot          phase0.Root
+	// FinalitySafeExecutionBlockHash is an execution block hash guaranteed to be
+	// present on the EL, for use as a forkchoiceUpdated safe/finalized hash. See
+	// agnosticFinalitySafeExecutionBlockHash.
+	FinalitySafeExecutionBlockHash phase0.Hash32
+	ParentRoot                     phase0.Root
+	StateRoot                      phase0.Root
 }
 
 // FinalityInfo contains finality checkpoint execution block hashes.
@@ -345,12 +349,18 @@ func (c *Client) GetBlockInfo(ctx context.Context, blockID string) (*BlockInfo, 
 		return nil, fmt.Errorf("failed to get execution block hash: %w", err)
 	}
 
+	finalitySafeHash, err := agnosticFinalitySafeExecutionBlockHash(msg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get finality-safe execution block hash: %w", err)
+	}
+
 	return &BlockInfo{
-		Slot:               msg.Slot,
-		Root:               root,
-		ExecutionBlockHash: execBlockHash,
-		ParentRoot:         msg.ParentRoot,
-		StateRoot:          msg.StateRoot,
+		Slot:                           msg.Slot,
+		Root:                           root,
+		ExecutionBlockHash:             execBlockHash,
+		FinalitySafeExecutionBlockHash: finalitySafeHash,
+		ParentRoot:                     msg.ParentRoot,
+		StateRoot:                      msg.StateRoot,
 	}, nil
 }
 
@@ -367,6 +377,38 @@ func agnosticExecutionBlockHash(msg *all.BeaconBlock) (phase0.Hash32, error) {
 		}
 
 		return body.SignedExecutionPayloadBid.Message.BlockHash, nil
+	}
+
+	if body.ExecutionPayload == nil {
+		return phase0.Hash32{}, fmt.Errorf("no execution payload in block")
+	}
+
+	return body.ExecutionPayload.BlockHash, nil
+}
+
+// agnosticFinalitySafeExecutionBlockHash returns an execution block hash that is
+// guaranteed to be present on the execution layer, suitable for use as a
+// forkchoiceUpdated safe/finalized hash.
+//
+// Pre-Gloas the payload is embedded in the beacon block, so the committed block
+// hash is always present once the block is imported. From Gloas on, a block only
+// commits to a builder *bid* whose payload may have been withheld (never revealed,
+// so never imported by the EL) — sending that committed block hash as safe/
+// finalized makes the EL reject the forkchoiceUpdated ("A fork choice element was
+// not found" / "safe block not available in database"). The bid's
+// parent_block_hash, however, is the execution block the builder built upon: by
+// definition an already-revealed, canonical payload that the EL has. It is an
+// ancestor of the block (hence still finalized/justified) and is always present,
+// which is exactly what safe/finalized require.
+func agnosticFinalitySafeExecutionBlockHash(msg *all.BeaconBlock) (phase0.Hash32, error) {
+	body := msg.Body
+
+	if msg.Version >= version.DataVersionGloas {
+		if body.SignedExecutionPayloadBid == nil || body.SignedExecutionPayloadBid.Message == nil {
+			return phase0.Hash32{}, fmt.Errorf("no execution payload bid in block")
+		}
+
+		return body.SignedExecutionPayloadBid.Message.ParentBlockHash, nil
 	}
 
 	if body.ExecutionPayload == nil {
@@ -410,7 +452,7 @@ func (c *Client) GetFinalityInfo(ctx context.Context) (*FinalityInfo, error) {
 			c.log.WithError(err).Warn("Failed to get safe block info, using head")
 			safeBlockHash = headInfo.ExecutionBlockHash
 		} else {
-			safeBlockHash = safeInfo.ExecutionBlockHash
+			safeBlockHash = safeInfo.FinalitySafeExecutionBlockHash
 		}
 	} else {
 		safeBlockHash = headInfo.ExecutionBlockHash
@@ -425,7 +467,7 @@ func (c *Client) GetFinalityInfo(ctx context.Context) (*FinalityInfo, error) {
 			c.log.WithError(err).Warn("Failed to get finalized block info, using safe")
 			finalizedBlockHash = safeBlockHash
 		} else {
-			finalizedBlockHash = finalizedInfo.ExecutionBlockHash
+			finalizedBlockHash = finalizedInfo.FinalitySafeExecutionBlockHash
 		}
 	} else {
 		finalizedBlockHash = safeBlockHash

--- a/pkg/rpc/beacon/client.go
+++ b/pkg/rpc/beacon/client.go
@@ -299,9 +299,8 @@ type BlockInfo struct {
 	Slot               phase0.Slot
 	Root               phase0.Root
 	ExecutionBlockHash phase0.Hash32
-	// FinalitySafeExecutionBlockHash is an execution block hash guaranteed to be
-	// present on the EL, for use as a forkchoiceUpdated safe/finalized hash. See
-	// agnosticFinalitySafeExecutionBlockHash.
+	// Execution block hash safe to use as an FCU safe/finalized hash; always
+	// present on the EL. See agnosticFinalitySafeExecutionBlockHash.
 	FinalitySafeExecutionBlockHash phase0.Hash32
 	ParentRoot                     phase0.Root
 	StateRoot                      phase0.Root
@@ -386,20 +385,12 @@ func agnosticExecutionBlockHash(msg *all.BeaconBlock) (phase0.Hash32, error) {
 	return body.ExecutionPayload.BlockHash, nil
 }
 
-// agnosticFinalitySafeExecutionBlockHash returns an execution block hash that is
-// guaranteed to be present on the execution layer, suitable for use as a
-// forkchoiceUpdated safe/finalized hash.
-//
-// Pre-Gloas the payload is embedded in the beacon block, so the committed block
-// hash is always present once the block is imported. From Gloas on, a block only
-// commits to a builder *bid* whose payload may have been withheld (never revealed,
-// so never imported by the EL) — sending that committed block hash as safe/
-// finalized makes the EL reject the forkchoiceUpdated ("A fork choice element was
-// not found" / "safe block not available in database"). The bid's
-// parent_block_hash, however, is the execution block the builder built upon: by
-// definition an already-revealed, canonical payload that the EL has. It is an
-// ancestor of the block (hence still finalized/justified) and is always present,
-// which is exactly what safe/finalized require.
+// agnosticFinalitySafeExecutionBlockHash returns an execution block hash safe to
+// use as a forkchoiceUpdated safe/finalized hash: one the EL is guaranteed to
+// have. A Gloas block's committed bid block_hash may belong to a withheld payload
+// the EL never imported, so use the bid's parent_block_hash instead — the block
+// the builder built upon, an already-revealed ancestor. Pre-Gloas the payload is
+// embedded, so the block hash is always present.
 func agnosticFinalitySafeExecutionBlockHash(msg *all.BeaconBlock) (phase0.Hash32, error) {
 	body := msg.Body
 


### PR DESCRIPTION
## Problem

Buildoor intermittently fails to build payloads for a full epoch after an epoch boundary, then self-heals:

```
forkchoiceUpdated failed: engine API error -38002: Invalid forkchoice state
("A fork choice element (Finalized) was not found, but an ancestor was, so it's not a sync problem.")
```
(geth phrases the same condition as `"safe block not available in database"`.)

## Root cause — ePBS payload availability

A Gloas beacon block does **not** embed its execution payload; it only commits to a builder *bid*. `GetBlockInfo` / `agnosticExecutionBlockHash` returned that bid's committed `block_hash` as the block's execution hash, and `GetFinalityInfo` used it for the forkchoiceUpdated **safe** and **finalized** hashes.

When the justified/finalized checkpoint block's payload was **withheld** — revealed late or never, so never imported by the EL — that committed block hash does not exist on the execution layer, and the engine rejects the entire `forkchoiceUpdated`. It clears at the next epoch boundary once a checkpoint whose payload *was* revealed takes over.

This was confirmed against live devnet data: the epoch-boundary checkpoint block (e.g. slot 40) had `payload_present: false` in the next block's payload attestation, and `eth_getBlockByHash(committed_hash)` returned `null` on geth — while the bid's `parent_block_hash` was present.

## Fix

Add `agnosticFinalitySafeExecutionBlockHash`: for Gloas blocks it returns the bid's **`parent_block_hash`** instead of the committed `block_hash`. The parent is the execution block the builder built upon — by definition an already-revealed, canonical payload the EL has, and still a valid finalized/justified ancestor (these checkpoints are ≥1 epoch old, so being one EL block conservative is harmless). Pre-Gloas blocks embed the payload, so the committed hash is always present and behaviour is unchanged. `GetFinalityInfo` uses this for both the safe and finalized hashes.

## Verification

A/B tested on a kurtosis devnet (`ethrex`+`geth` × `lodestar`+`lighthouse`, gloas at epoch 1, minimal preset), running the published image and this fix side by side as dedicated builders on the same network:

| Arm | Image | FCU "Finalized not found" errors |
|---|---|---|
| Baseline | published `glamsterdam-devnet-6` | **20 per builder** across several epoch boundaries |
| Fixed | this PR | **0** — builds cleanly through the same slots |

> Note: this supersedes the first commit on this branch, which targeted finality-view consistency — the A/B test showed that hypothesis was wrong (both arms failed identically), which led to the real payload-availability root cause above. Branch history squashed to the correct fix.