### PR TITLE
Use zero root for signing bid (pre-Gloas) & Use `MaxWithdrawalsPerPayload` from spec

### DIFF
--- a/pkg/builderapi/fulu/build.go
+++ b/pkg/builderapi/fulu/build.go
@@ -26,12 +26,13 @@ func BuildSignedBuilderBid(
 	blsSigner BidSigner,
 	subsidyGwei uint64,
 	genesisForkVersion phase0.Version,
+	maxWithdrawalsPerPayload uint64,
 ) (*SignedBuilderBid, error) {
 	if event == nil || event.ExecutionPayload == nil {
 		return nil, nil
 	}
 
-	header, err := ExecutionPayloadHeaderFromBeacon(event.ExecutionPayload)
+	header, err := ExecutionPayloadHeaderFromBeacon(event.ExecutionPayload, maxWithdrawalsPerPayload)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/builderapi/fulu/build.go
+++ b/pkg/builderapi/fulu/build.go
@@ -18,7 +18,7 @@ type BidSigner interface {
 
 // BuildSignedBuilderBid builds a Fulu SignedBuilderBid from a Payload and the proposer's pubkey,
 // and signs it with the builder's BLS key using DOMAIN_APPLICATION_BUILDER with the provided genesis fork version
-// and genesis validators root (matches mev-boost-relay behavior).
+// and a zero genesis validators root (matches mev-boost-relay behavior).
 // subsidyGwei is added to the bid value so the proposer sees a higher bid (e.g. for testing).
 func BuildSignedBuilderBid(
 	event *payload_builder.Payload,
@@ -26,7 +26,6 @@ func BuildSignedBuilderBid(
 	blsSigner BidSigner,
 	subsidyGwei uint64,
 	genesisForkVersion phase0.Version,
-	genesisValidatorsRoot phase0.Root,
 ) (*SignedBuilderBid, error) {
 	if event == nil || event.ExecutionPayload == nil {
 		return nil, nil
@@ -72,11 +71,12 @@ func BuildSignedBuilderBid(
 
 	var root phase0.Root
 	copy(root[:], bidRoot[:])
+	var zeroRoot phase0.Root
 
 	domain := signer.ComputeDomain(
 		signer.DomainApplicationBuilder,
 		genesisForkVersion,
-		genesisValidatorsRoot,
+		zeroRoot,
 	)
 
 	sig, err := blsSigner.SignWithDomain(root, domain)

--- a/pkg/builderapi/fulu/build_test.go
+++ b/pkg/builderapi/fulu/build_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	eth2all "github.com/ethpandaops/go-eth2-client/spec/all"
+	"github.com/ethpandaops/go-eth2-client/spec/capella"
 	"github.com/ethpandaops/go-eth2-client/spec/phase0"
 	"github.com/ethpandaops/go-eth2-client/spec/version"
 	"github.com/stretchr/testify/assert"
@@ -21,7 +22,7 @@ func TestBuildSignedBuilderBid_NilEvent(t *testing.T) {
 	pk := blsSigner.PublicKey()
 
 	var genesisForkVersion phase0.Version // zero version
-	bid, err := BuildSignedBuilderBid(nil, pk, blsSigner, 0, genesisForkVersion)
+	bid, err := BuildSignedBuilderBid(nil, pk, blsSigner, 0, genesisForkVersion, defaultMaxWithdrawalsPerPayload)
 	require.NoError(t, err)
 	assert.Nil(t, bid)
 }
@@ -35,7 +36,7 @@ func TestBuildSignedBuilderBid_NoSubsidy(t *testing.T) {
 	event := minimalPayload(t, blockValue)
 
 	var genesisForkVersion phase0.Version // zero version
-	bid, err := BuildSignedBuilderBid(event, pk, blsSigner, 0, genesisForkVersion)
+	bid, err := BuildSignedBuilderBid(event, pk, blsSigner, 0, genesisForkVersion, defaultMaxWithdrawalsPerPayload)
 	require.NoError(t, err)
 	require.NotNil(t, bid)
 	require.NotNil(t, bid.Message)
@@ -54,7 +55,7 @@ func TestBuildSignedBuilderBid_SubsidyAdded(t *testing.T) {
 	event := minimalPayload(t, blockValue)
 
 	var genesisForkVersion phase0.Version // zero version
-	bid, err := BuildSignedBuilderBid(event, pk, blsSigner, subsidy, genesisForkVersion)
+	bid, err := BuildSignedBuilderBid(event, pk, blsSigner, subsidy, genesisForkVersion, defaultMaxWithdrawalsPerPayload)
 	require.NoError(t, err)
 	require.NotNil(t, bid)
 	require.NotNil(t, bid.Message)
@@ -71,7 +72,7 @@ func TestBuildSignedBuilderBid_SignsWithZeroGenesisValidatorsRoot(t *testing.T) 
 	pk := blsSigner.PublicKey()
 
 	genesisForkVersion := phase0.Version{1, 2, 3, 4}
-	bid, err := BuildSignedBuilderBid(minimalPayload(t, big.NewInt(1)), pk, blsSigner, 0, genesisForkVersion)
+	bid, err := BuildSignedBuilderBid(minimalPayload(t, big.NewInt(1)), pk, blsSigner, 0, genesisForkVersion, defaultMaxWithdrawalsPerPayload)
 	require.NoError(t, err)
 	require.NotNil(t, bid)
 
@@ -89,6 +90,27 @@ func TestBuildSignedBuilderBid_SignsWithZeroGenesisValidatorsRoot(t *testing.T) 
 	wrongDomain := signer.ComputeDomain(signer.DomainApplicationBuilder, genesisForkVersion, nonZeroRoot)
 	wrongSigningRoot := signer.ComputeSigningRoot(root, wrongDomain)
 	require.False(t, signer.VerifyBLSSignature(pk, wrongSigningRoot[:], bid.Signature))
+}
+
+func TestExecutionPayloadHeaderFromBeacon_UsesMaxWithdrawalsPerPayload(t *testing.T) {
+	payload := minimalPayload(t, big.NewInt(1)).ExecutionPayload
+	payload.Withdrawals = []*capella.Withdrawal{{
+		Index:          1,
+		ValidatorIndex: 2,
+		Amount:         3,
+	}}
+
+	header, err := ExecutionPayloadHeaderFromBeacon(payload, 4)
+	require.NoError(t, err)
+	require.NotNil(t, header)
+
+	minimalRoot, err := withdrawalsRoot(payload.Withdrawals, 4)
+	require.NoError(t, err)
+	mainnetRoot, err := withdrawalsRoot(payload.Withdrawals, 16)
+	require.NoError(t, err)
+
+	assert.Equal(t, phase0.Root(minimalRoot), header.WithdrawalsRoot)
+	assert.NotEqual(t, mainnetRoot, minimalRoot)
 }
 
 func minimalPayload(t *testing.T, blockValue *big.Int) *payload_builder.Payload {

--- a/pkg/builderapi/fulu/build_test.go
+++ b/pkg/builderapi/fulu/build_test.go
@@ -21,9 +21,7 @@ func TestBuildSignedBuilderBid_NilEvent(t *testing.T) {
 	pk := blsSigner.PublicKey()
 
 	var genesisForkVersion phase0.Version // zero version
-	var genesisValidatorsRoot phase0.Root // zero root
-
-	bid, err := BuildSignedBuilderBid(nil, pk, blsSigner, 0, genesisForkVersion, genesisValidatorsRoot)
+	bid, err := BuildSignedBuilderBid(nil, pk, blsSigner, 0, genesisForkVersion)
 	require.NoError(t, err)
 	assert.Nil(t, bid)
 }
@@ -37,9 +35,7 @@ func TestBuildSignedBuilderBid_NoSubsidy(t *testing.T) {
 	event := minimalPayload(t, blockValue)
 
 	var genesisForkVersion phase0.Version // zero version
-	var genesisValidatorsRoot phase0.Root // zero root
-
-	bid, err := BuildSignedBuilderBid(event, pk, blsSigner, 0, genesisForkVersion, genesisValidatorsRoot)
+	bid, err := BuildSignedBuilderBid(event, pk, blsSigner, 0, genesisForkVersion)
 	require.NoError(t, err)
 	require.NotNil(t, bid)
 	require.NotNil(t, bid.Message)
@@ -58,9 +54,7 @@ func TestBuildSignedBuilderBid_SubsidyAdded(t *testing.T) {
 	event := minimalPayload(t, blockValue)
 
 	var genesisForkVersion phase0.Version // zero version
-	var genesisValidatorsRoot phase0.Root // zero root
-
-	bid, err := BuildSignedBuilderBid(event, pk, blsSigner, subsidy, genesisForkVersion, genesisValidatorsRoot)
+	bid, err := BuildSignedBuilderBid(event, pk, blsSigner, subsidy, genesisForkVersion)
 	require.NoError(t, err)
 	require.NotNil(t, bid)
 	require.NotNil(t, bid.Message)
@@ -69,6 +63,32 @@ func TestBuildSignedBuilderBid_SubsidyAdded(t *testing.T) {
 	expected := new(big.Int).Add(blockValue, new(big.Int).SetUint64(subsidy*1_000_000_000))
 	assert.Equal(t, expected.Uint64(), bid.Message.Value.Uint64(),
 		"bid value should be block_value_wei + subsidy_gwei_converted_to_wei")
+}
+
+func TestBuildSignedBuilderBid_SignsWithZeroGenesisValidatorsRoot(t *testing.T) {
+	blsSigner, err := signer.NewBLSSigner("0x0000000000000000000000000000000000000000000000000000000000000001")
+	require.NoError(t, err)
+	pk := blsSigner.PublicKey()
+
+	genesisForkVersion := phase0.Version{1, 2, 3, 4}
+	bid, err := BuildSignedBuilderBid(minimalPayload(t, big.NewInt(1)), pk, blsSigner, 0, genesisForkVersion)
+	require.NoError(t, err)
+	require.NotNil(t, bid)
+
+	bidRoot, err := bid.Message.HashTreeRoot()
+	require.NoError(t, err)
+	var root phase0.Root
+	copy(root[:], bidRoot[:])
+
+	var zeroRoot phase0.Root
+	domain := signer.ComputeDomain(signer.DomainApplicationBuilder, genesisForkVersion, zeroRoot)
+	signingRoot := signer.ComputeSigningRoot(root, domain)
+	require.True(t, signer.VerifyBLSSignature(pk, signingRoot[:], bid.Signature))
+
+	nonZeroRoot := phase0.Root{1}
+	wrongDomain := signer.ComputeDomain(signer.DomainApplicationBuilder, genesisForkVersion, nonZeroRoot)
+	wrongSigningRoot := signer.ComputeSigningRoot(root, wrongDomain)
+	require.False(t, signer.VerifyBLSSignature(pk, wrongSigningRoot[:], bid.Signature))
 }
 
 func minimalPayload(t *testing.T, blockValue *big.Int) *payload_builder.Payload {

--- a/pkg/builderapi/fulu/header.go
+++ b/pkg/builderapi/fulu/header.go
@@ -11,10 +11,12 @@ import (
 	"github.com/pk910/dynamic-ssz/sszutils"
 )
 
+const defaultMaxWithdrawalsPerPayload = 16
+
 // ExecutionPayloadHeaderFromBeacon builds a deneb.ExecutionPayloadHeader from
 // the fork-agnostic beacon execution payload. Used to construct a Fulu
 // BuilderBid for getHeader responses.
-func ExecutionPayloadHeaderFromBeacon(p *eth2all.ExecutionPayload) (*deneb.ExecutionPayloadHeader, error) {
+func ExecutionPayloadHeaderFromBeacon(p *eth2all.ExecutionPayload, maxWithdrawalsPerPayload uint64) (*deneb.ExecutionPayloadHeader, error) {
 	if p == nil {
 		return nil, nil
 	}
@@ -53,7 +55,7 @@ func ExecutionPayloadHeaderFromBeacon(p *eth2all.ExecutionPayload) (*deneb.Execu
 	}
 	header.TransactionsRoot = phase0.Root(txRoot)
 
-	withdrawalsRoot, err := withdrawalsRoot(p.Withdrawals)
+	withdrawalsRoot, err := withdrawalsRoot(p.Withdrawals, maxWithdrawalsPerPayload)
 	if err != nil {
 		return nil, err
 	}
@@ -68,7 +70,10 @@ func transactionsRoot(txs [][]byte) ([32]byte, error) {
 }
 
 // withdrawalsRoot computes the SSZ hash tree root of the withdrawals list.
-func withdrawalsRoot(list []*capella.Withdrawal) ([32]byte, error) {
+func withdrawalsRoot(list []*capella.Withdrawal, maxWithdrawalsPerPayload uint64) ([32]byte, error) {
+	if maxWithdrawalsPerPayload == 0 {
+		maxWithdrawalsPerPayload = defaultMaxWithdrawalsPerPayload
+	}
 	var root [32]byte
 	err := hasher.WithDefaultHasher(func(hh sszutils.HashWalker) error {
 		idx := hh.Index()
@@ -78,7 +83,7 @@ func withdrawalsRoot(list []*capella.Withdrawal) ([32]byte, error) {
 			}
 		}
 		vlen := uint64(len(list))
-		hh.MerkleizeWithMixin(idx, vlen, sszutils.CalculateLimit(16, vlen, 32))
+		hh.MerkleizeWithMixin(idx, vlen, sszutils.CalculateLimit(maxWithdrawalsPerPayload, vlen, 32))
 		var err error
 		root, err = hh.HashRoot()
 		return err

--- a/pkg/builderapi/server.go
+++ b/pkg/builderapi/server.go
@@ -493,7 +493,11 @@ func (s *Server) handleGetHeader(w http.ResponseWriter, r *http.Request) {
 		subsidyGwei = s.cfg.BlockValueSubsidyGwei
 	}
 	log.Info("Subsidy Gwei: " + fmt.Sprintf("%d", subsidyGwei))
-	signedBid, err := fulu.BuildSignedBuilderBid(event, s.blsSigner.PublicKey(), s.blsSigner, subsidyGwei, s.chainSvc.GetGenesis().GenesisForkVersion)
+	maxWithdrawalsPerPayload := uint64(0)
+	if chainSpec := s.chainSvc.GetChainSpec(); chainSpec != nil {
+		maxWithdrawalsPerPayload = chainSpec.MaxWithdrawalsPerPayload
+	}
+	signedBid, err := fulu.BuildSignedBuilderBid(event, s.blsSigner.PublicKey(), s.blsSigner, subsidyGwei, s.chainSvc.GetGenesis().GenesisForkVersion, maxWithdrawalsPerPayload)
 	if err != nil {
 		log.WithError(err).Warn("getHeader: failed to build SignedBuilderBid")
 		writeValidatorError(w, http.StatusInternalServerError, "failed to build bid")

--- a/pkg/builderapi/server.go
+++ b/pkg/builderapi/server.go
@@ -493,7 +493,7 @@ func (s *Server) handleGetHeader(w http.ResponseWriter, r *http.Request) {
 		subsidyGwei = s.cfg.BlockValueSubsidyGwei
 	}
 	log.Info("Subsidy Gwei: " + fmt.Sprintf("%d", subsidyGwei))
-	signedBid, err := fulu.BuildSignedBuilderBid(event, s.blsSigner.PublicKey(), s.blsSigner, subsidyGwei, s.chainSvc.GetGenesis().GenesisForkVersion, s.chainSvc.GetGenesis().GenesisValidatorsRoot)
+	signedBid, err := fulu.BuildSignedBuilderBid(event, s.blsSigner.PublicKey(), s.blsSigner, subsidyGwei, s.chainSvc.GetGenesis().GenesisForkVersion)
 	if err != nil {
 		log.WithError(err).Warn("getHeader: failed to build SignedBuilderBid")
 		writeValidatorError(w, http.StatusInternalServerError, "failed to build bid")

--- a/pkg/chain/spec.go
+++ b/pkg/chain/spec.go
@@ -39,6 +39,7 @@ type ChainSpec struct {
 	MaxPendingDepositsPerEpoch          uint64
 	MinActivationBalance                uint64
 	EffectiveBalanceIncrement           uint64
+	MaxWithdrawalsPerPayload            uint64
 
 	// Domain types
 	DomainBeaconProposer      phase0.DomainType
@@ -159,6 +160,12 @@ func (s *ChainSpec) parseSpecData(specData map[string]string, rawData map[string
 
 	if v, err := parseSpecUint64(specData, "EFFECTIVE_BALANCE_INCREMENT"); err == nil {
 		s.EffectiveBalanceIncrement = v
+	}
+
+	if v, err := parseSpecUint64(specData, "MAX_WITHDRAWALS_PER_PAYLOAD"); err == nil {
+		s.MaxWithdrawalsPerPayload = v
+	} else {
+		s.MaxWithdrawalsPerPayload = 16
 	}
 
 	// Parse domain types


### PR DESCRIPTION
- Current Buildoor puts the actual genesis validator root when signing the bid. This deviates from the [spec](https://github.com/ethereum/builder-specs/blob/78a5546d9d8253beabf7db8baf988a58abdec87f/specs/bellatrix/builder.md#packaging-into-a-signedbuilderbid) that it puts zero root for genesis validator root.
- Also as now `MaxWithdrawalsPerPayload` is anchored to the mainnet default value `16` - we need some flexibility here.