### PR TITLE
change early-onboarding withdrawal prefix from 0x03 to 0xB0

### DIFF
--- a/pkg/lifecycle/contract.go
+++ b/pkg/lifecycle/contract.go
@@ -46,8 +46,8 @@ const (
 	builderWithdrawalPrefix = 0x00
 	// validatorWithdrawalPrefix is the withdrawal-credential prefix used for the
 	// pre-Gloas early-onboarding deposit, which goes through the regular validator
-	// deposit contract (execution-address / 0x03-style credentials).
-	validatorWithdrawalPrefix = 0x03
+	// deposit contract (builder-prefix / 0xB0 credentials).
+	validatorWithdrawalPrefix = 0xB0
 )
 
 // excessInhibitor is the EXCESS_INHIBITOR (2^256-1) stored in slot 0 of the
@@ -174,7 +174,7 @@ func BuilderWithdrawalCredentials(walletAddress common.Address) [32]byte {
 
 // ValidatorWithdrawalCredentials builds the withdrawal credentials for the pre-Gloas
 // early-onboarding deposit, which is submitted through the regular validator deposit
-// contract. Format: 0x03 + 00...00 (11 zero bytes) + wallet_address (20 bytes).
+// contract. Format: 0xB0 + 00...00 (11 zero bytes) + wallet_address (20 bytes).
 func ValidatorWithdrawalCredentials(walletAddress common.Address) [32]byte {
 	return buildWithdrawalCredentials(validatorWithdrawalPrefix, walletAddress)
 }

--- a/pkg/lifecycle/contract_test.go
+++ b/pkg/lifecycle/contract_test.go
@@ -38,7 +38,7 @@ func TestBuildBuilderDepositCalldata(t *testing.T) {
 	}
 
 	var wc [32]byte
-	wc[0] = 0x03
+	wc[0] = 0xB0
 
 	sig := make([]byte, 96)
 	for i := range sig {
@@ -95,7 +95,7 @@ func TestWithdrawalCredentials(t *testing.T) {
 		wantPrefix byte
 	}{
 		{"builder uses 0x00 prefix", BuilderWithdrawalCredentials(addr), 0x00},
-		{"validator uses 0x03 prefix", ValidatorWithdrawalCredentials(addr), 0x03},
+		{"validator uses 0xB0 prefix", ValidatorWithdrawalCredentials(addr), 0xB0},
 	}
 
 	for _, tt := range tests {

--- a/pkg/lifecycle/early_deposit.go
+++ b/pkg/lifecycle/early_deposit.go
@@ -31,7 +31,7 @@ const depositContractABI = `[{"name":"deposit","type":"function","stateMutabilit
 
 // EarlyDepositService submits a pre-Gloas builder onboarding deposit via the regular
 // validator deposit contract. Unlike the post-fork builder deposit (EIP-8282 predeploy,
-// 0x00 withdrawal prefix, DOMAIN_BUILDER_DEPOSIT), an early deposit uses 0x03 withdrawal
+// 0x00 withdrawal prefix, DOMAIN_BUILDER_DEPOSIT), an early deposit uses 0xB0 withdrawal
 // credentials and is signed with the validator deposit domain — i.e. it is an ordinary
 // validator deposit that sits in the beacon state's pending_deposits queue and is
 // converted into a builder at the Gloas fork boundary.
@@ -87,7 +87,7 @@ func (s *EarlyDepositService) HasPendingDeposit() bool {
 }
 
 // CreateEarlyDeposit builds, signs and sends a validator deposit for this builder via
-// the regular deposit contract. The deposit uses 0x03 (execution-address) withdrawal
+// the regular deposit contract. The deposit uses 0xB0 (BUILDER_WITHDRAWAL_PREFIX) withdrawal
 // credentials pointing at the funding wallet and is signed with the validator deposit
 // domain over GENESIS_FORK_VERSION.
 func (s *EarlyDepositService) CreateEarlyDeposit(ctx context.Context, amountGwei uint64) error {

--- a/pkg/signer/bls.go
+++ b/pkg/signer/bls.go
@@ -22,7 +22,7 @@ var (
 
 	// DomainDeposit is the standard domain for validator deposit signatures, and for
 	// the genesis builder-onboarding path (a pre-fork deposit to the validator deposit
-	// contract with a 0x03 credential, per the Gloas spec).
+	// contract with a 0xB0 credential, per the Gloas spec).
 	DomainDeposit = phase0.DomainType{0x03, 0x00, 0x00, 0x00}
 
 	// DomainBuilderDeposit is DOMAIN_BUILDER_DEPOSIT (Gloas, 0x0E000000): the dedicated

--- a/pkg/signer/bls_test.go
+++ b/pkg/signer/bls_test.go
@@ -18,7 +18,7 @@ func TestDepositRootComputation(t *testing.T) {
 	}
 
 	var wc [32]byte
-	wc[0] = 0x03
+	wc[0] = 0xB0
 	for i := 12; i < 32; i++ {
 		wc[i] = byte(i)
 	}


### PR DESCRIPTION
`BUILDER_WITHDRAWAL_PREFIX` changed from `0x03` to `0xB0` in ethereum/consensus-specs#5416 (lands in v1.7.0-alpha.12, targeted by glamsterdam-devnet-7).

The pre-Gloas early-onboarding deposit submitted through the regular validator deposit contract must now carry `0xB0`-prefixed withdrawal credentials, otherwise the deposit stays pending as an ordinary validator deposit and the builder is never onboarded at the fork (`onboard_builders_from_pending_deposits` matches on the prefix).

Not changed, different namespaces:
- EIP-8282 builder-deposit-contract path credentials (`0x00` prefix)
- `DOMAIN_DEPOSIT` (`0x03000000`)
- EIP-8282 deposit request type `0x03`

`go build ./...` and `go test ./pkg/...` pass.