### PR TITLE
fix alpha.12 payload deadline and builder deposit prefix

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -82,7 +82,7 @@ func init() {
 	// ePBS time-based flags (0 = auto from slot time, scaled from the 12s value)
 	rootCmd.PersistentFlags().Int64("epbs-bid-start", 0, "First bid time in ms relative to slot start (0 = auto: -400ms @12s, scaled to slot time)")
 	rootCmd.PersistentFlags().Int64("epbs-bid-end", 0, "Last bid time in ms relative to slot start (0 = auto: -100ms @12s, scaled to slot time)")
-	rootCmd.PersistentFlags().Int64("epbs-reveal-time", 0, "Reveal time in ms relative to slot start (0 = auto: 7000ms @12s, scaled to slot time)")
+	rootCmd.PersistentFlags().Int64("epbs-reveal-time", 0, "Reveal time in ms relative to slot start (0 = auto: 5000ms @12s, scaled to slot time)")
 	rootCmd.PersistentFlags().Uint64("epbs-bid-min", defaults.EPBS.BidMinAmount, "Minimum bid amount in gwei")
 	rootCmd.PersistentFlags().Uint64("epbs-bid-increase", defaults.EPBS.BidIncrease, "Bid increase per subsequent bid in gwei")
 	rootCmd.PersistentFlags().Int64("epbs-bid-interval", defaults.EPBS.BidInterval, "Interval between bids in ms (0 = single bid)")

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -48,15 +48,15 @@ const referenceSlotTimeMs = 12000
 //	PayloadBuildTime: 2100ms @12s  (e.g.  1050ms @6s)
 //	BidStartTime:     -400ms @12s  (e.g.  -200ms @6s)
 //	BidEndTime:       -100ms @12s  (e.g.   -50ms @6s)
-//	RevealTime:       7000ms @12s  (e.g.  3500ms @6s)
+//	RevealTime:       5000ms @12s  (e.g.  2500ms @6s)
 //
-// RevealTime (58.3% of the slot) is anchored to the Gloas/EIP-7732 deadlines:
-// it sits after the attestation-aggregate deadline (AGGREGATE_DUE_BPS_GLOAS,
-// 50%) — so the builder has seen enough attestation weight to know the block is
-// the canonical head before committing to reveal — and comfortably before the
-// hard payload deadline (PAYLOAD_DUE_BPS / PAYLOAD_ATTESTATION_DUE_BPS, 75%),
-// after which the PTC votes the payload absent. The ~17% (2s @12s) margin lets
-// the envelope gossip to PTC members before they attest at 75%.
+// RevealTime (41.7% of the slot) is anchored to the Gloas/EIP-7732 deadlines:
+// it sits after the attestation deadline (ATTESTATION_DUE_BPS_GLOAS, 25%) — so
+// the builder has seen attestation weight on the block before committing to
+// reveal — and comfortably before the hard payload deadline (PAYLOAD_DUE_BPS,
+// 50% since consensus-specs#5414), after which the PTC votes the payload
+// absent. The ~8% (1s @12s) margin lets the envelope gossip to PTC members
+// before they attest at 75% (PAYLOAD_ATTESTATION_DUE_BPS).
 func (c *Config) ApplySlotDefaults(slotTimeMs int64) {
 	if c.EPBS.BuildStartTime == 0 {
 		c.EPBS.BuildStartTime = -2900 * slotTimeMs / referenceSlotTimeMs
@@ -75,6 +75,6 @@ func (c *Config) ApplySlotDefaults(slotTimeMs int64) {
 	}
 
 	if c.EPBS.RevealTime == 0 {
-		c.EPBS.RevealTime = 7000 * slotTimeMs / referenceSlotTimeMs
+		c.EPBS.RevealTime = 5000 * slotTimeMs / referenceSlotTimeMs
 	}
 }

--- a/pkg/lifecycle/contract.go
+++ b/pkg/lifecycle/contract.go
@@ -42,8 +42,11 @@ const (
 	queueFeeHeadroom = 3
 
 	// builderWithdrawalPrefix is the withdrawal-credential prefix for builder
-	// deposits submitted via the EIP-8282 builder deposit contract.
-	builderWithdrawalPrefix = 0x00
+	// deposits submitted via the EIP-8282 builder deposit contract. Must be
+	// BUILDER_WITHDRAWAL_PREFIX (0xB0): since consensus-specs#5439 (alpha.12),
+	// process_builder_deposit_request silently ignores deposits with any other
+	// prefix.
+	builderWithdrawalPrefix = 0xB0
 	// validatorWithdrawalPrefix is the withdrawal-credential prefix used for the
 	// pre-Gloas early-onboarding deposit, which goes through the regular validator
 	// deposit contract (builder-prefix / 0xB0 credentials).

--- a/pkg/lifecycle/contract_test.go
+++ b/pkg/lifecycle/contract_test.go
@@ -94,7 +94,7 @@ func TestWithdrawalCredentials(t *testing.T) {
 		creds      [32]byte
 		wantPrefix byte
 	}{
-		{"builder uses 0x00 prefix", BuilderWithdrawalCredentials(addr), 0x00},
+		{"builder uses 0xB0 prefix", BuilderWithdrawalCredentials(addr), 0xB0},
 		{"validator uses 0xB0 prefix", ValidatorWithdrawalCredentials(addr), 0xB0},
 	}
 

--- a/pkg/lifecycle/early_deposit.go
+++ b/pkg/lifecycle/early_deposit.go
@@ -30,9 +30,9 @@ const depositContractABI = `[{"name":"deposit","type":"function","stateMutabilit
 	`{"name":"deposit_data_root","type":"bytes32"}]}]`
 
 // EarlyDepositService submits a pre-Gloas builder onboarding deposit via the regular
-// validator deposit contract. Unlike the post-fork builder deposit (EIP-8282 predeploy,
-// 0x00 withdrawal prefix, DOMAIN_BUILDER_DEPOSIT), an early deposit uses 0xB0 withdrawal
-// credentials and is signed with the validator deposit domain — i.e. it is an ordinary
+// validator deposit contract. Both paths use 0xB0 withdrawal credentials, but unlike
+// the post-fork builder deposit (EIP-8282 predeploy, DOMAIN_BUILDER_DEPOSIT), an early
+// deposit is signed with the validator deposit domain — i.e. it is an ordinary
 // validator deposit that sits in the beacon state's pending_deposits queue and is
 // converted into a builder at the Gloas fork boundary.
 type EarlyDepositService struct {


### PR DESCRIPTION
consensus-specs v1.7.0-alpha.12 includes two changes that break the current devnet-7 branch defaults:

- [#5414](https://github.com/ethereum/consensus-specs/pull/5414) moved the payload deadline to 50% of the slot (`PAYLOAD_DUE_BPS` 7500 → 5000). The default reveal time of 7000ms @12s now fires **1s after** the deadline, so the PTC would vote every payload absent. Dropped the default to 5000ms @12s (1s margin before the 6s deadline, still after the 25% attestation deadline).
- [#5439](https://github.com/ethereum/consensus-specs/pull/5439) restricts builder deposits to `BUILDER_WITHDRAWAL_PREFIX` (0xB0) credentials — `process_builder_deposit_request` now silently ignores anything else. The EIP-8282 predeploy deposit path still used 0x00, so post-fork deposits/top-ups would be dropped on-chain. Switched to 0xB0.

Follow-up to #130, which covered the early-onboarding path only.