### PR TITLE
Update builder contract addresses for glamsterdam-devnet-7

### DIFF
--- a/pkg/lifecycle/contract.go
+++ b/pkg/lifecycle/contract.go
@@ -24,9 +24,9 @@ import (
 // canonical addresses and match dora's DefaultSystemContractAddresses.
 var (
 	// BuilderDepositContractAddress is the EIP-8282 builder deposit predeploy.
-	BuilderDepositContractAddress = common.HexToAddress("0x00006AE84ed173D4394de5E28F9ED56b28008282")
+	BuilderDepositContractAddress = common.HexToAddress("0x0000bFF46984e3725691FA540a8C7589300D8282")
 	// BuilderExitContractAddress is the EIP-8282 builder exit predeploy.
-	BuilderExitContractAddress = common.HexToAddress("0x000014574A74c805590AFF9499fc7A690f008282")
+	BuilderExitContractAddress = common.HexToAddress("0x000064D678505ad48F8cCb093BC65613800E8282")
 )
 
 const (


### PR DESCRIPTION
Bring the contract addresses in line with https://notes.ethereum.org/@ethpandaops/glamsterdam-devnet-7 .