### PR TITLE
Add exact-slot payload reveal withholding for ePBS testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,24 @@ buildoor run \
   --wallet-privkey <ECDSA_PRIVATE_KEY>
 ```
 
+### Exact-slot reveal withholding
+
+For deterministic Gloas/ePBS fault testing, future slots can be configured to
+build and bid normally while intentionally withholding the payload-envelope
+publication:
+
+```bash
+curl -X POST http://localhost:8082/api/config/epbs \
+  -H 'Content-Type: application/json' \
+  -d '{"slot_actions":{"384":{"reveal":"withhold"}}}'
+```
+
+Supplying `slot_actions` replaces all pending future actions; use an empty
+object to clear them. Current and past slots are rejected. A winning configured
+slot emits an `intentionally_withheld` event on `/api/events` containing the
+slot, builder index and public key, action, status, and timestamp. The built
+payload remains in Buildoor's payload cache for inspection.
+
 ### Builder API Example
 
 ```bash

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -168,8 +168,22 @@ and begins building blocks according to configuration.`,
 		// Configure the global dynssz instance with this network's spec so the
 		// go-eth2-client SSZ codecs (block.Root(), envelope HashTreeRoot, ...)
 		// compute correct hash-tree-roots on non-mainnet presets (e.g. minimal).
-		if err := clClient.InitGlobalSSZSpecs(ctx); err != nil {
-			return fmt.Errorf("failed to init global SSZ specs: %w", err)
+		for {
+			err = clClient.InitGlobalSSZSpecs(ctx)
+			if err == nil {
+				break
+			}
+
+			// A beacon node can serve /config/spec and /genesis just before it
+			// reports an active client to the follow-up SSZ initialization call.
+			// Treat that readiness window like the preceding startup probes.
+			logger.WithError(err).Warn("Beacon node SSZ specs not ready, retrying in 5s...")
+
+			select {
+			case <-ctx.Done():
+				return fmt.Errorf("failed to init global SSZ specs: %w", ctx.Err())
+			case <-time.After(5 * time.Second):
+			}
 		}
 
 		// Apply slot-relative timing defaults now that we know the slot duration
@@ -279,12 +293,25 @@ and begins building blocks according to configuration.`,
 
 		var revealSvc *payload_bidder.RevealService
 
+		var slotActionsStore *payload_bidder.SlotActionsStore
+
 		epbsAvailable := chainSpec.IsForkScheduled(version.DataVersionGloas)
 
 		if epbsAvailable {
 			paymentTracker = payload_bidder.NewPaymentTracker(chainSvc, logger)
 
-			revealSvc = payload_bidder.NewRevealService(cfg, payload_bidder.NewSigner(blsSigner), clClient, chainSvc, builderSvc, paymentTracker, logger)
+			// Per-slot reveal actions (fault injection for Gloas/ePBS testing),
+			// configured via POST /api/config/epbs and consumed by the reveal
+			// service. Persisted via the kv_store; stale entries from a previous
+			// run are pruned on start.
+			slotActionsStore = payload_bidder.NewSlotActionsStore()
+			slotActionsStore.SetPersistence(ctx, stateDB, logger)
+			slotActionsStore.PruneBefore(chainSvc.GetCurrentSlot())
+			// Registered after stateDB's own close defer (LIFO) → the store's
+			// final flush runs while the state-db is still open.
+			defer slotActionsStore.Stop()
+
+			revealSvc = payload_bidder.NewRevealService(cfg, payload_bidder.NewSigner(blsSigner), clClient, chainSvc, builderSvc, paymentTracker, slotActionsStore, logger)
 			if err := revealSvc.Start(ctx); err != nil {
 				return fmt.Errorf("failed to start reveal service: %w", err)
 			}
@@ -414,7 +441,7 @@ and begins building blocks according to configuration.`,
 				AuthProviderURL: cfg.AuthProviderURL,
 				InjectHeadHTML:  cfg.InjectHeadHTML,
 				OverviewURL:     cfg.OverviewURL,
-			}, settingsSvc, stateDB, builderSvc, epbsSvc, lifecycleMgr, chainSvc, validatorStore, builderAPISrv, propPrefSvc, valRanges, revealSvc, inclusionTracker, paymentTracker)
+			}, settingsSvc, stateDB, builderSvc, epbsSvc, lifecycleMgr, chainSvc, validatorStore, builderAPISrv, propPrefSvc, valRanges, revealSvc, inclusionTracker, paymentTracker, slotActionsStore)
 
 			// Connect Builder API server to event stream (if both are enabled)
 			if builderAPISrv != nil && apiHandler != nil {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -306,9 +306,9 @@ and begins building blocks according to configuration.`,
 			// run are pruned on start.
 			slotActionsStore = payload_bidder.NewSlotActionsStore()
 			slotActionsStore.SetPersistence(ctx, stateDB, logger)
-			slotActionsStore.PruneBefore(chainSvc.GetCurrentSlot())
+			slotActionsStore.StartPruning(ctx, chainSvc)
 			// Registered after stateDB's own close defer (LIFO) → the store's
-			// final flush runs while the state-db is still open.
+			// pruner stops and its final flush runs while the state-db is open.
 			defer slotActionsStore.Stop()
 
 			revealSvc = payload_bidder.NewRevealService(cfg, payload_bidder.NewSigner(blsSigner), clClient, chainSvc, builderSvc, paymentTracker, slotActionsStore, logger)

--- a/pkg/builderapi/epbs/handler_test.go
+++ b/pkg/builderapi/epbs/handler_test.go
@@ -202,7 +202,7 @@ func newBeaconBlockTestEnv(t *testing.T, slotDuration time.Duration, revealTimeM
 
 	publisher := &stubEnvelopePublisher{}
 	revealSvc := payload_bidder.NewRevealService(
-		cfg, payload_bidder.NewSigner(blsSigner), publisher, chainSvc, builderSvc, nil, log)
+		cfg, payload_bidder.NewSigner(blsSigner), publisher, chainSvc, builderSvc, nil, nil, log)
 
 	broadcaster := &stubBlockBroadcaster{}
 

--- a/pkg/payload_bidder/bid.go
+++ b/pkg/payload_bidder/bid.go
@@ -86,11 +86,11 @@ func BuildSignedBid(
 // go-eth2-client v0.1.6 fork-agnostic view uses progressive lists, which is a
 // different SSZ type and therefore commits a different root into the bid.
 type gloasExecutionRequestsSigningView struct {
-	Deposits        []*electra.DepositRequest       `ssz-max:"8192"`
-	Withdrawals     []*electra.WithdrawalRequest    `ssz-max:"16"`
-	Consolidations  []*electra.ConsolidationRequest `ssz-max:"2"`
-	BuilderDeposits []*gloas.BuilderDepositRequest  `ssz-max:"256"`
-	BuilderExits    []*gloas.BuilderExitRequest     `ssz-max:"16"`
+	Deposits        []*electra.DepositRequest       `dynssz-max:"MAX_DEPOSIT_REQUESTS_PER_PAYLOAD" ssz-max:"8192"`
+	Withdrawals     []*electra.WithdrawalRequest    `dynssz-max:"MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD" ssz-max:"16"`
+	Consolidations  []*electra.ConsolidationRequest `dynssz-max:"MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD" ssz-max:"2"`
+	BuilderDeposits []*gloas.BuilderDepositRequest  `dynssz-max:"MAX_BUILDER_DEPOSIT_REQUESTS_PER_PAYLOAD" ssz-max:"256"`
+	BuilderExits    []*gloas.BuilderExitRequest     `dynssz-max:"MAX_BUILDER_EXIT_REQUESTS_PER_PAYLOAD" ssz-max:"16"`
 }
 
 func hashGloasExecutionRequests(requests *eth2all.ExecutionRequests) (phase0.Root, error) {

--- a/pkg/payload_bidder/bid.go
+++ b/pkg/payload_bidder/bid.go
@@ -6,6 +6,7 @@ import (
 	eth2all "github.com/ethpandaops/go-eth2-client/spec/all"
 	"github.com/ethpandaops/go-eth2-client/spec/bellatrix"
 	"github.com/ethpandaops/go-eth2-client/spec/deneb"
+	"github.com/ethpandaops/go-eth2-client/spec/electra"
 	"github.com/ethpandaops/go-eth2-client/spec/gloas"
 	"github.com/ethpandaops/go-eth2-client/spec/phase0"
 	dynssz "github.com/pk910/dynamic-ssz"
@@ -41,7 +42,7 @@ func BuildSignedBid(
 	}
 
 	// dynssz so preset-dependent list limits resolve from the global spec.
-	execRequestsRoot, err := dynssz.GetGlobalDynSsz().HashTreeRoot(execRequests)
+	execRequestsRoot, err := hashGloasExecutionRequests(execRequests)
 	if err != nil {
 		return nil, fmt.Errorf("failed to compute execution requests root: %w", err)
 	}
@@ -78,4 +79,33 @@ func BuildSignedBid(
 		Message:   bid,
 		Signature: sig,
 	}, nil
+}
+
+// gloasExecutionRequestsSigningView pins the five request collections to the
+// bounded-list schema used by the Glamsterdam Gloas specification. The
+// go-eth2-client v0.1.6 fork-agnostic view uses progressive lists, which is a
+// different SSZ type and therefore commits a different root into the bid.
+type gloasExecutionRequestsSigningView struct {
+	Deposits        []*electra.DepositRequest       `ssz-max:"8192"`
+	Withdrawals     []*electra.WithdrawalRequest    `ssz-max:"16"`
+	Consolidations  []*electra.ConsolidationRequest `ssz-max:"2"`
+	BuilderDeposits []*gloas.BuilderDepositRequest  `ssz-max:"256"`
+	BuilderExits    []*gloas.BuilderExitRequest     `ssz-max:"16"`
+}
+
+func hashGloasExecutionRequests(requests *eth2all.ExecutionRequests) (phase0.Root, error) {
+	view := &gloasExecutionRequestsSigningView{
+		Deposits:        requests.Deposits,
+		Withdrawals:     requests.Withdrawals,
+		Consolidations:  requests.Consolidations,
+		BuilderDeposits: requests.BuilderDeposits,
+		BuilderExits:    requests.BuilderExits,
+	}
+
+	root, err := dynssz.GetGlobalDynSsz().HashTreeRoot(view)
+	if err != nil {
+		return phase0.Root{}, fmt.Errorf("failed to compute Gloas execution requests root: %w", err)
+	}
+
+	return phase0.Root(root), nil
 }

--- a/pkg/payload_bidder/inclusion_tracker.go
+++ b/pkg/payload_bidder/inclusion_tracker.go
@@ -168,6 +168,14 @@ func (t *InclusionTracker) processHead(event *beacon.HeadEvent) {
 		return
 	}
 
+	// The head event is the authoritative source for the canonical block root.
+	// In particular, go-eth2-client v0.1.6 hashes the nested Gloas bid's blob
+	// commitments as a progressive list, while Glamsterdam uses a bounded list;
+	// recomputing the block root through that schema makes an otherwise valid
+	// envelope reference an unknown block. Keep the decoded block for all other
+	// fields, but preserve the root supplied by the beacon node.
+	blockInfo.Root = event.Block
+
 	t.processBlockInfo(blockInfo)
 }
 

--- a/pkg/payload_bidder/inclusion_tracker_test.go
+++ b/pkg/payload_bidder/inclusion_tracker_test.go
@@ -110,7 +110,7 @@ func TestInclusionTracker_GloasGatingAndInclusion(t *testing.T) {
 
 			// Not started: RequestReveal just queues on the buffered channel.
 			revealSvc := NewRevealService(&config.Config{}, NewSigner(blsSigner), &mockEnvelopePublisher{},
-				chainSvc, builderSvc, payments, logger)
+				chainSvc, builderSvc, payments, nil, logger)
 
 			tracker := NewInclusionTracker(nil, chainSvc, builderSvc, revealSvc, payments, logger)
 			includedSub := tracker.SubscribeIncluded(4)

--- a/pkg/payload_bidder/mockchain_test.go
+++ b/pkg/payload_bidder/mockchain_test.go
@@ -27,6 +27,7 @@ type stubChainService struct {
 	slotDuration time.Duration
 	currentFork  version.DataVersion
 	genesis      beacon.Genesis
+	currentSlot  func() phase0.Slot
 
 	epochStatsDispatch utils.Dispatcher[*chain.EpochStats]
 }
@@ -50,7 +51,13 @@ func (m *stubChainService) TimeToSlot(t time.Time) phase0.Slot {
 }
 
 func (m *stubChainService) GetCurrentEpoch() phase0.Epoch { return 0 }
-func (m *stubChainService) GetCurrentSlot() phase0.Slot   { return 0 }
+func (m *stubChainService) GetCurrentSlot() phase0.Slot {
+	if m.currentSlot != nil {
+		return m.currentSlot()
+	}
+
+	return 0
+}
 
 func (m *stubChainService) GetCurrentFork() version.DataVersion { return m.currentFork }
 func (m *stubChainService) ActiveForkAtEpoch(phase0.Epoch) version.DataVersion {

--- a/pkg/payload_bidder/reveal.go
+++ b/pkg/payload_bidder/reveal.go
@@ -30,10 +30,15 @@ func BuildSignedEnvelope(
 	forkVersion phase0.Version,
 	genesisValidatorsRoot phase0.Root,
 ) (signed *eth2all.SignedExecutionPayloadEnvelope, blobs, proofs [][]byte, err error) {
+	execRequests := p.ExecutionRequests
+	if execRequests == nil {
+		execRequests = &eth2all.ExecutionRequests{Version: p.ExecutionPayload.Version}
+	}
+
 	envelope := &eth2all.ExecutionPayloadEnvelope{
 		Version:               p.ExecutionPayload.Version,
 		Payload:               p.ExecutionPayload,
-		ExecutionRequests:     p.ExecutionRequests,
+		ExecutionRequests:     execRequests,
 		BuilderIndex:          gloas.BuilderIndex(rc.BuilderIndex),
 		BeaconBlockRoot:       rc.BeaconBlockRoot,
 		ParentBeaconBlockRoot: rc.ParentBeaconBlockRoot,

--- a/pkg/payload_bidder/reveal_service.go
+++ b/pkg/payload_bidder/reveal_service.go
@@ -42,6 +42,14 @@ type RevealResult struct {
 	Error       string // failure reason (when Success is false)
 	Attempt     int    // 1-based
 	MaxAttempts int
+
+	// Withheld reveals (configured per-slot fault injection); the builder
+	// identity fields are populated so the event doubles as the receipt that
+	// the configured fault was applied.
+	Withheld      bool   // reveal intentionally withheld by a slot action
+	Action        string // the configured action (RevealActionWithhold)
+	BuilderIndex  uint64
+	BuilderPubkey string
 }
 
 const (
@@ -64,6 +72,7 @@ type RevealService struct {
 	chainSvc     chain.Service
 	builderSvc   *payload_builder.Service // reveal success/failure stats
 	payments     *PaymentTracker          // optional; nil-guarded
+	slotActions  *SlotActionsStore        // optional; nil-guarded (per-slot fault injection)
 	builderIndex atomic.Uint64
 
 	requests chan *RevealRequest
@@ -84,7 +93,8 @@ type revealState struct {
 	done        bool
 }
 
-// NewRevealService creates a new reveal service.
+// NewRevealService creates a new reveal service. slotActions may be nil (no
+// per-slot fault injection).
 func NewRevealService(
 	cfg *config.Config,
 	signer *Signer,
@@ -92,18 +102,20 @@ func NewRevealService(
 	chainSvc chain.Service,
 	builderSvc *payload_builder.Service,
 	payments *PaymentTracker,
+	slotActions *SlotActionsStore,
 	log logrus.FieldLogger,
 ) *RevealService {
 	return &RevealService{
-		cfg:        cfg,
-		signer:     signer,
-		publisher:  publisher,
-		chainSvc:   chainSvc,
-		builderSvc: builderSvc,
-		payments:   payments,
-		requests:   make(chan *RevealRequest, 16),
-		pending:    make(map[phase0.Slot]*revealState, 8),
-		log:        log.WithField("component", "reveal-service"),
+		cfg:         cfg,
+		signer:      signer,
+		publisher:   publisher,
+		chainSvc:    chainSvc,
+		builderSvc:  builderSvc,
+		payments:    payments,
+		slotActions: slotActions,
+		requests:    make(chan *RevealRequest, 16),
+		pending:     make(map[phase0.Slot]*revealState, 8),
+		log:         log.WithField("component", "reveal-service"),
 	}
 }
 
@@ -191,6 +203,33 @@ func (s *RevealService) schedule(req *RevealRequest) {
 			"slot":      slot,
 			"transport": req.Transport,
 		}).Debug("Duplicate reveal request for slot, ignoring")
+
+		return
+	}
+
+	// Per-slot fault injection: a configured "withhold" action suppresses the
+	// envelope publication entirely. The done marker keeps the slot's dedup
+	// semantics (exactly one withheld event, no timer, no retries); the
+	// payload stays untouched in the payload cache for inspection, and the
+	// pending payment is left to expire like any other missed reveal.
+	if action, ok := s.slotActionFor(slot); ok && action.Reveal == RevealActionWithhold {
+		s.pending[slot] = &revealState{req: req, done: true}
+
+		s.results.Fire(&RevealResult{
+			Slot:          slot,
+			Transport:     req.Transport,
+			Withheld:      true,
+			Action:        RevealActionWithhold,
+			BuilderIndex:  s.builderIndex.Load(),
+			BuilderPubkey: s.signer.Pubkey().String(),
+		})
+
+		s.log.WithFields(logrus.Fields{
+			"slot":       slot,
+			"transport":  req.Transport,
+			"action":     RevealActionWithhold,
+			"block_hash": fmt.Sprintf("%x", req.Payload.BlockHash[:8]),
+		}).Warn("Intentionally withholding payload envelope reveal (configured slot action)")
 
 		return
 	}
@@ -361,6 +400,21 @@ func (s *RevealService) rearm(timer *time.Timer) {
 	}
 
 	timer.Reset(next)
+}
+
+// slotActionFor returns the configured action for a slot; nil-guards the
+// optional store.
+func (s *RevealService) slotActionFor(slot phase0.Slot) (*SlotAction, bool) {
+	if s.slotActions == nil {
+		return nil, false
+	}
+
+	action, ok := s.slotActions.Get(slot)
+	if !ok || action == nil {
+		return nil, false
+	}
+
+	return action, true
 }
 
 // publish builds and signs the payload's envelope and submits it (with blobs /

--- a/pkg/payload_bidder/reveal_service_test.go
+++ b/pkg/payload_bidder/reveal_service_test.go
@@ -54,12 +54,13 @@ func (p *mockEnvelopePublisher) callCount() int {
 
 // revealTestEnv bundles the wiring shared by the reveal service tests.
 type revealTestEnv struct {
-	cfg        *config.Config
-	chainSvc   *stubChainService
-	builderSvc *payload_builder.Service
-	payments   *PaymentTracker
-	publisher  *mockEnvelopePublisher
-	svc        *RevealService
+	cfg         *config.Config
+	chainSvc    *stubChainService
+	builderSvc  *payload_builder.Service
+	payments    *PaymentTracker
+	publisher   *mockEnvelopePublisher
+	slotActions *SlotActionsStore
+	svc         *RevealService
 }
 
 // newRevealTestEnv creates a reveal service whose slot 1 starts "now", with
@@ -84,16 +85,18 @@ func newRevealTestEnv(t *testing.T, slotDuration time.Duration, revealTimeMs int
 	builderSvc := newTestBuilderSvc(chainSvc)
 	payments := NewPaymentTracker(chainSvc, log)
 	publisher := &mockEnvelopePublisher{}
+	slotActions := NewSlotActionsStore()
 
-	svc := NewRevealService(cfg, NewSigner(blsSigner), publisher, chainSvc, builderSvc, payments, log)
+	svc := NewRevealService(cfg, NewSigner(blsSigner), publisher, chainSvc, builderSvc, payments, slotActions, log)
 
 	return &revealTestEnv{
-		cfg:        cfg,
-		chainSvc:   chainSvc,
-		builderSvc: builderSvc,
-		payments:   payments,
-		publisher:  publisher,
-		svc:        svc,
+		cfg:         cfg,
+		chainSvc:    chainSvc,
+		builderSvc:  builderSvc,
+		payments:    payments,
+		publisher:   publisher,
+		slotActions: slotActions,
+		svc:         svc,
 	}
 }
 
@@ -115,6 +118,11 @@ func TestRevealService_RevealsAtDueTime(t *testing.T) {
 	sub := env.svc.SubscribeResults(4)
 
 	defer sub.Unsubscribe()
+
+	// A withhold action for a DIFFERENT slot must not affect this reveal.
+	env.slotActions.ReplaceFuture(map[phase0.Slot]*SlotAction{
+		2: {Reveal: RevealActionWithhold},
+	}, 0)
 
 	require.NoError(t, env.svc.Start(context.Background()))
 	defer env.svc.Stop()
@@ -247,6 +255,94 @@ func TestRevealService_RetriesThenGivesUp(t *testing.T) {
 	assert.Nil(t, payload.Reveal(), "payload must not be marked revealed")
 	assert.Equal(t, uint64(42), env.payments.GetTotalPendingPayments(), "payment must stay pending")
 	assert.Equal(t, uint64(1), env.builderSvc.GetStats().RevealsFailed)
+}
+
+func TestRevealService_WithholdsConfiguredSlot(t *testing.T) {
+	env := newRevealTestEnv(t, 4*time.Second, 10)
+	sub := env.svc.SubscribeResults(4)
+
+	defer sub.Unsubscribe()
+
+	// Slot 1 (starting now) is configured to withhold its reveal.
+	env.slotActions.ReplaceFuture(map[phase0.Slot]*SlotAction{
+		1: {Reveal: RevealActionWithhold},
+	}, 0)
+
+	require.NoError(t, env.svc.Start(context.Background()))
+	defer env.svc.Stop()
+
+	env.svc.SetBuilderIndex(42)
+
+	slot := phase0.Slot(1)
+	payload := newTestPayload(slot, phase0.Hash32{0xab}, big.NewInt(2_000_000_000_000)) // 2000 gwei
+
+	env.payments.RecordWonBid(slot, 2000)
+
+	env.svc.RequestReveal(&RevealRequest{
+		Payload:   payload,
+		BlockInfo: &beacon.BlockInfo{Slot: slot, Root: phase0.Root{0x11}, ParentRoot: phase0.Root{0x22}},
+		Transport: payload_builder.BidTransportP2P,
+	})
+
+	res := waitForResult(t, sub.Channel(), 2*time.Second)
+	assert.True(t, res.Withheld)
+	assert.Equal(t, RevealActionWithhold, res.Action)
+	assert.False(t, res.Success)
+	assert.False(t, res.Skipped)
+	assert.Equal(t, slot, res.Slot)
+	assert.Equal(t, payload_builder.BidTransportP2P, res.Transport)
+	assert.Equal(t, uint64(42), res.BuilderIndex)
+	assert.NotEmpty(t, res.BuilderPubkey)
+
+	// Well past the reveal due time: nothing may publish.
+	time.Sleep(300 * time.Millisecond)
+	assert.Equal(t, 0, env.publisher.callCount(), "withheld slot must never publish")
+	assert.Nil(t, payload.Reveal(), "payload must not be marked revealed")
+	assert.Equal(t, uint64(2000), env.payments.GetTotalPendingPayments(), "payment must stay pending")
+	assert.Equal(t, uint64(0), env.builderSvc.GetStats().RevealsSuccess)
+	assert.Equal(t, uint64(0), env.builderSvc.GetStats().RevealsFailed)
+}
+
+func TestRevealService_WithholdDedupsBySlot(t *testing.T) {
+	env := newRevealTestEnv(t, 4*time.Second, 10)
+	sub := env.svc.SubscribeResults(4)
+
+	defer sub.Unsubscribe()
+
+	env.slotActions.ReplaceFuture(map[phase0.Slot]*SlotAction{
+		1: {Reveal: RevealActionWithhold},
+	}, 0)
+
+	require.NoError(t, env.svc.Start(context.Background()))
+	defer env.svc.Stop()
+
+	slot := phase0.Slot(1)
+	payload := newTestPayload(slot, phase0.Hash32{0xab}, big.NewInt(1))
+	blockInfo := &beacon.BlockInfo{Slot: slot, Root: phase0.Root{0x11}, ParentRoot: phase0.Root{0x22}}
+
+	// Both flows request the reveal for the same slot; exactly one withheld
+	// event may fire and nothing may publish.
+	env.svc.RequestReveal(&RevealRequest{
+		Payload: payload, BlockInfo: blockInfo,
+		Transport: payload_builder.BidTransportBuilderAPI,
+	})
+	env.svc.RequestReveal(&RevealRequest{
+		Payload: payload, BlockInfo: blockInfo,
+		Transport: payload_builder.BidTransportP2P,
+	})
+
+	res := waitForResult(t, sub.Channel(), 2*time.Second)
+	assert.True(t, res.Withheld)
+	assert.Equal(t, payload_builder.BidTransportBuilderAPI, res.Transport, "first transport wins")
+
+	time.Sleep(300 * time.Millisecond)
+	assert.Equal(t, 0, env.publisher.callCount())
+
+	select {
+	case extra := <-sub.Channel():
+		t.Fatalf("unexpected second reveal result: %+v", extra)
+	default:
+	}
 }
 
 func TestRevealService_SkipsStaleSlot(t *testing.T) {

--- a/pkg/payload_bidder/signer.go
+++ b/pkg/payload_bidder/signer.go
@@ -127,7 +127,7 @@ type gloasBidSigningView struct {
 	Slot                  phase0.Slot
 	Value                 phase0.Gwei
 	ExecutionPayment      phase0.Gwei
-	BlobKZGCommitments    []deneb.KZGCommitment `ssz-max:"4096" ssz-size:"?,48"`
+	BlobKZGCommitments    []deneb.KZGCommitment `dynssz-max:"MAX_BLOB_COMMITMENTS_PER_BLOCK" ssz-max:"4096" ssz-size:"?,48"`
 	ExecutionRequestsRoot phase0.Root           `ssz-size:"32"`
 }
 
@@ -166,14 +166,14 @@ type gloasPayloadSigningView struct {
 	GasLimit        uint64
 	GasUsed         uint64
 	Timestamp       uint64
-	ExtraData       []byte `ssz-max:"32"`
+	ExtraData       []byte `dynssz-max:"MAX_EXTRA_DATA_BYTES" ssz-max:"32"`
 	BaseFeePerGas   [32]byte
 	BlockHash       phase0.Hash32           `ssz-size:"32"`
-	Transactions    []bellatrix.Transaction `ssz-max:"1048576,1073741824" ssz-size:"?,?"`
-	Withdrawals     []*capella.Withdrawal   `ssz-max:"16"`
+	Transactions    []bellatrix.Transaction `dynssz-max:"MAX_TRANSACTIONS_PER_PAYLOAD,MAX_BYTES_PER_TRANSACTION" ssz-max:"1048576,1073741824" ssz-size:"?,?"`
+	Withdrawals     []*capella.Withdrawal   `dynssz-max:"MAX_WITHDRAWALS_PER_PAYLOAD" ssz-max:"16"`
 	BlobGasUsed     uint64
 	ExcessBlobGas   uint64
-	BlockAccessList gloas.BlockAccessList `ssz-max:"1073741824"`
+	BlockAccessList gloas.BlockAccessList `dynssz-max:"MAX_BYTES_PER_TRANSACTION" ssz-max:"1073741824"`
 	SlotNumber      uint64
 }
 

--- a/pkg/payload_bidder/signer.go
+++ b/pkg/payload_bidder/signer.go
@@ -15,7 +15,12 @@ import (
 	"fmt"
 
 	eth2all "github.com/ethpandaops/go-eth2-client/spec/all"
+	"github.com/ethpandaops/go-eth2-client/spec/bellatrix"
+	"github.com/ethpandaops/go-eth2-client/spec/capella"
+	"github.com/ethpandaops/go-eth2-client/spec/deneb"
+	"github.com/ethpandaops/go-eth2-client/spec/gloas"
 	"github.com/ethpandaops/go-eth2-client/spec/phase0"
+	"github.com/ethpandaops/go-eth2-client/spec/version"
 	dynssz "github.com/pk910/dynamic-ssz"
 
 	"github.com/ethpandaops/buildoor/pkg/signer"
@@ -35,6 +40,11 @@ func NewSigner(blsSigner *signer.BLSSigner) *Signer {
 	return &Signer{blsSigner: blsSigner}
 }
 
+// Pubkey returns the builder's BLS public key.
+func (s *Signer) Pubkey() phase0.BLSPubKey {
+	return s.blsSigner.PublicKey()
+}
+
 // SignBid signs an execution payload bid. forkVersion must be the fork version
 // the consensus client verifies against (the Gloas fork version).
 func (s *Signer) SignBid(
@@ -42,6 +52,15 @@ func (s *Signer) SignBid(
 	forkVersion phase0.Version,
 	genesisValidatorsRoot phase0.Root,
 ) (phase0.BLSSignature, error) {
+	if bid.Version == version.DataVersionGloas {
+		root, err := hashGloasBid(bid)
+		if err != nil {
+			return phase0.BLSSignature{}, err
+		}
+
+		return s.signRoot(root, forkVersion, genesisValidatorsRoot)
+	}
+
 	return s.sign(bid, forkVersion, genesisValidatorsRoot)
 }
 
@@ -51,6 +70,15 @@ func (s *Signer) SignEnvelope(
 	forkVersion phase0.Version,
 	genesisValidatorsRoot phase0.Root,
 ) (phase0.BLSSignature, error) {
+	if envelope.Version == version.DataVersionGloas {
+		root, err := hashGloasEnvelope(envelope)
+		if err != nil {
+			return phase0.BLSSignature{}, err
+		}
+
+		return s.signRoot(root, forkVersion, genesisValidatorsRoot)
+	}
+
 	return s.sign(envelope, forkVersion, genesisValidatorsRoot)
 }
 
@@ -70,8 +98,138 @@ func (s *Signer) sign(
 	var root phase0.Root
 
 	copy(root[:], msgRoot[:])
+	return s.signRoot(root, forkVersion, genesisValidatorsRoot)
+}
+
+func (s *Signer) signRoot(
+	root phase0.Root,
+	forkVersion phase0.Version,
+	genesisValidatorsRoot phase0.Root,
+) (phase0.BLSSignature, error) {
 
 	domain := signer.ComputeDomain(DomainBeaconBuilder, forkVersion, genesisValidatorsRoot)
 
 	return s.blsSigner.SignWithDomain(root, domain)
+}
+
+// gloasBidSigningView pins the Gloas commitments field to the bounded-list
+// schema used by the Glamsterdam consensus specification. go-eth2-client
+// v0.1.6 models this field as a progressive list, which produces a different
+// signing root even though its JSON and wire fields are otherwise identical.
+type gloasBidSigningView struct {
+	ParentBlockHash       phase0.Hash32              `ssz-size:"32"`
+	ParentBlockRoot       phase0.Root                `ssz-size:"32"`
+	BlockHash             phase0.Hash32              `ssz-size:"32"`
+	PrevRandao            phase0.Root                `ssz-size:"32"`
+	FeeRecipient          bellatrix.ExecutionAddress `ssz-size:"20"`
+	GasLimit              uint64
+	BuilderIndex          gloas.BuilderIndex
+	Slot                  phase0.Slot
+	Value                 phase0.Gwei
+	ExecutionPayment      phase0.Gwei
+	BlobKZGCommitments    []deneb.KZGCommitment `ssz-max:"4096" ssz-size:"?,48"`
+	ExecutionRequestsRoot phase0.Root           `ssz-size:"32"`
+}
+
+func hashGloasBid(bid *eth2all.ExecutionPayloadBid) (phase0.Root, error) {
+	view := &gloasBidSigningView{
+		ParentBlockHash:       bid.ParentBlockHash,
+		ParentBlockRoot:       bid.ParentBlockRoot,
+		BlockHash:             bid.BlockHash,
+		PrevRandao:            bid.PrevRandao,
+		FeeRecipient:          bid.FeeRecipient,
+		GasLimit:              bid.GasLimit,
+		BuilderIndex:          bid.BuilderIndex,
+		Slot:                  bid.Slot,
+		Value:                 bid.Value,
+		ExecutionPayment:      bid.ExecutionPayment,
+		BlobKZGCommitments:    bid.BlobKZGCommitments,
+		ExecutionRequestsRoot: bid.ExecutionRequestsRoot,
+	}
+
+	root, err := dynssz.GetGlobalDynSsz().HashTreeRoot(view)
+	if err != nil {
+		return phase0.Root{}, fmt.Errorf("failed to compute Gloas bid hash tree root: %w", err)
+	}
+
+	return phase0.Root(root), nil
+}
+
+type gloasPayloadSigningView struct {
+	ParentHash      phase0.Hash32              `ssz-size:"32"`
+	FeeRecipient    bellatrix.ExecutionAddress `ssz-size:"20"`
+	StateRoot       phase0.Root                `ssz-size:"32"`
+	ReceiptsRoot    phase0.Root                `ssz-size:"32"`
+	LogsBloom       [256]byte                  `ssz-size:"256"`
+	PrevRandao      [32]byte                   `ssz-size:"32"`
+	BlockNumber     uint64
+	GasLimit        uint64
+	GasUsed         uint64
+	Timestamp       uint64
+	ExtraData       []byte `ssz-max:"32"`
+	BaseFeePerGas   [32]byte
+	BlockHash       phase0.Hash32           `ssz-size:"32"`
+	Transactions    []bellatrix.Transaction `ssz-max:"1048576,1073741824" ssz-size:"?,?"`
+	Withdrawals     []*capella.Withdrawal   `ssz-max:"16"`
+	BlobGasUsed     uint64
+	ExcessBlobGas   uint64
+	BlockAccessList gloas.BlockAccessList `ssz-max:"1073741824"`
+	SlotNumber      uint64
+}
+
+type gloasEnvelopeSigningView struct {
+	Payload               *gloasPayloadSigningView
+	ExecutionRequests     *gloasExecutionRequestsSigningView
+	BuilderIndex          gloas.BuilderIndex
+	BeaconBlockRoot       phase0.Root `ssz-size:"32"`
+	ParentBeaconBlockRoot phase0.Root `ssz-size:"32"`
+}
+
+func hashGloasEnvelope(envelope *eth2all.ExecutionPayloadEnvelope) (phase0.Root, error) {
+	payload := envelope.Payload
+	requests := envelope.ExecutionRequests
+	if payload == nil || requests == nil {
+		return phase0.Root{}, fmt.Errorf("gloas envelope payload and execution requests are required")
+	}
+
+	view := &gloasEnvelopeSigningView{
+		Payload: &gloasPayloadSigningView{
+			ParentHash:      payload.ParentHash,
+			FeeRecipient:    payload.FeeRecipient,
+			StateRoot:       payload.StateRoot,
+			ReceiptsRoot:    payload.ReceiptsRoot,
+			LogsBloom:       payload.LogsBloom,
+			PrevRandao:      payload.PrevRandao,
+			BlockNumber:     payload.BlockNumber,
+			GasLimit:        payload.GasLimit,
+			GasUsed:         payload.GasUsed,
+			Timestamp:       payload.Timestamp,
+			ExtraData:       payload.ExtraData,
+			BaseFeePerGas:   payload.BaseFeePerGasLE,
+			BlockHash:       payload.BlockHash,
+			Transactions:    payload.Transactions,
+			Withdrawals:     payload.Withdrawals,
+			BlobGasUsed:     payload.BlobGasUsed,
+			ExcessBlobGas:   payload.ExcessBlobGas,
+			BlockAccessList: payload.BlockAccessList,
+			SlotNumber:      payload.SlotNumber,
+		},
+		ExecutionRequests: &gloasExecutionRequestsSigningView{
+			Deposits:        requests.Deposits,
+			Withdrawals:     requests.Withdrawals,
+			Consolidations:  requests.Consolidations,
+			BuilderDeposits: requests.BuilderDeposits,
+			BuilderExits:    requests.BuilderExits,
+		},
+		BuilderIndex:          envelope.BuilderIndex,
+		BeaconBlockRoot:       envelope.BeaconBlockRoot,
+		ParentBeaconBlockRoot: envelope.ParentBeaconBlockRoot,
+	}
+
+	root, err := dynssz.GetGlobalDynSsz().HashTreeRoot(view)
+	if err != nil {
+		return phase0.Root{}, fmt.Errorf("failed to compute Gloas envelope hash tree root: %w", err)
+	}
+
+	return phase0.Root(root), nil
 }

--- a/pkg/payload_bidder/signer_test.go
+++ b/pkg/payload_bidder/signer_test.go
@@ -1,0 +1,74 @@
+package payload_bidder
+
+import (
+	"encoding/hex"
+	"testing"
+
+	eth2all "github.com/ethpandaops/go-eth2-client/spec/all"
+	"github.com/ethpandaops/go-eth2-client/spec/bellatrix"
+	"github.com/ethpandaops/go-eth2-client/spec/gloas"
+	"github.com/ethpandaops/go-eth2-client/spec/phase0"
+	"github.com/ethpandaops/go-eth2-client/spec/version"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGloasBidUsesBoundedCommitmentsListRoot(t *testing.T) {
+	decode := func(value string) []byte {
+		decoded, err := hex.DecodeString(value)
+		require.NoError(t, err)
+		return decoded
+	}
+	root := func(value string) (result phase0.Root) {
+		copy(result[:], decode(value))
+		return result
+	}
+
+	bid := &eth2all.ExecutionPayloadBid{
+		Version:               version.DataVersionGloas,
+		ParentBlockHash:       phase0.Hash32(root("882d22ed3a133fd42ba744661121f750e5bfa32fbdd5f08025f2356ff2d56962")),
+		ParentBlockRoot:       root("9474a47b8c7f35d85a5f59b6fb25e17471aa37ee228ecc3292d0e8551e84fa6b"),
+		BlockHash:             phase0.Hash32(root("7396438bc6390d1ef45bd0b842cfad8c3e782abbfb5381e6d9def8cef3d15a91")),
+		PrevRandao:            root("a86033297239e33101fccfaca4217a0ee291d957dbd86ab46211f70b53c0e0c5"),
+		FeeRecipient:          bellatrix.ExecutionAddress(decode("8943545177806ed17b9f23f0a21ee5948ecaa776")),
+		GasLimit:              150000000,
+		BuilderIndex:          gloas.BuilderIndex(0),
+		Slot:                  180,
+		Value:                 100000,
+		ExecutionPayment:      0,
+		BlobKZGCommitments:    nil,
+		ExecutionRequestsRoot: root("87b69a306c8e430d0857f7c4ac5e27cecffa1108d43c2e5df7388056fea7a423"),
+	}
+
+	actual, err := hashGloasBid(bid)
+	require.NoError(t, err)
+	require.Equal(t,
+		"05443306d810e015f5c790dc4be85203a1b7d1c9e4e5819e711c8b730500a598",
+		hex.EncodeToString(actual[:]),
+	)
+}
+
+func TestGloasExecutionRequestsUseBoundedListRoots(t *testing.T) {
+	actual, err := hashGloasExecutionRequests(&eth2all.ExecutionRequests{
+		Version: version.DataVersionGloas,
+	})
+	require.NoError(t, err)
+	require.Equal(t,
+		"3a02ed03ab3f2af7ef0e6ee1a44326479d2ab1d2f03613dd1ec0a11fcf37af96",
+		hex.EncodeToString(actual[:]),
+	)
+}
+
+func TestGloasEnvelopeUsesBoundedNestedListRoots(t *testing.T) {
+	actual, err := hashGloasEnvelope(&eth2all.ExecutionPayloadEnvelope{
+		Version:           version.DataVersionGloas,
+		Payload:           &eth2all.ExecutionPayload{Version: version.DataVersionGloas},
+		ExecutionRequests: &eth2all.ExecutionRequests{Version: version.DataVersionGloas},
+		BuilderIndex:      gloas.BuilderIndex(0),
+		BeaconBlockRoot:   phase0.Root{0x11},
+	})
+	require.NoError(t, err)
+	require.Equal(t,
+		"743eaf4d36852670927ebaa1cd7893ce86b0da831ad2da818bcb5dd740e1e546",
+		hex.EncodeToString(actual[:]),
+	)
+}

--- a/pkg/payload_bidder/signer_test.go
+++ b/pkg/payload_bidder/signer_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethpandaops/go-eth2-client/spec/gloas"
 	"github.com/ethpandaops/go-eth2-client/spec/phase0"
 	"github.com/ethpandaops/go-eth2-client/spec/version"
+	dynssz "github.com/pk910/dynamic-ssz"
 	"github.com/stretchr/testify/require"
 )
 
@@ -71,4 +72,54 @@ func TestGloasEnvelopeUsesBoundedNestedListRoots(t *testing.T) {
 		"743eaf4d36852670927ebaa1cd7893ce86b0da831ad2da818bcb5dd740e1e546",
 		hex.EncodeToString(actual[:]),
 	)
+}
+
+func TestGloasSigningViewsUseConnectedPresetLimits(t *testing.T) {
+	dynssz.SetGlobalSpecs(nil)
+	t.Cleanup(func() { dynssz.SetGlobalSpecs(nil) })
+
+	t.Run("bid commitments", func(t *testing.T) {
+		bid := &eth2all.ExecutionPayloadBid{Version: version.DataVersionGloas}
+		mainnetRoot, err := hashGloasBid(bid)
+		require.NoError(t, err)
+
+		dynssz.SetGlobalSpecs(map[string]any{
+			"MAX_BLOB_COMMITMENTS_PER_BLOCK": uint64(32),
+		})
+		presetRoot, err := hashGloasBid(bid)
+		require.NoError(t, err)
+		require.NotEqual(t, mainnetRoot, presetRoot)
+	})
+
+	t.Run("execution requests", func(t *testing.T) {
+		dynssz.SetGlobalSpecs(nil)
+		requests := &eth2all.ExecutionRequests{Version: version.DataVersionGloas}
+		mainnetRoot, err := hashGloasExecutionRequests(requests)
+		require.NoError(t, err)
+
+		dynssz.SetGlobalSpecs(map[string]any{
+			"MAX_DEPOSIT_REQUESTS_PER_PAYLOAD": uint64(16),
+		})
+		presetRoot, err := hashGloasExecutionRequests(requests)
+		require.NoError(t, err)
+		require.NotEqual(t, mainnetRoot, presetRoot)
+	})
+
+	t.Run("envelope withdrawals", func(t *testing.T) {
+		dynssz.SetGlobalSpecs(nil)
+		envelope := &eth2all.ExecutionPayloadEnvelope{
+			Version:           version.DataVersionGloas,
+			Payload:           &eth2all.ExecutionPayload{Version: version.DataVersionGloas},
+			ExecutionRequests: &eth2all.ExecutionRequests{Version: version.DataVersionGloas},
+		}
+		mainnetRoot, err := hashGloasEnvelope(envelope)
+		require.NoError(t, err)
+
+		dynssz.SetGlobalSpecs(map[string]any{
+			"MAX_WITHDRAWALS_PER_PAYLOAD": uint64(4),
+		})
+		presetRoot, err := hashGloasEnvelope(envelope)
+		require.NoError(t, err)
+		require.NotEqual(t, mainnetRoot, presetRoot)
+	})
 }

--- a/pkg/payload_bidder/slot_actions.go
+++ b/pkg/payload_bidder/slot_actions.go
@@ -6,10 +6,12 @@ import (
 	"fmt"
 	"strconv"
 	"sync"
+	"time"
 
 	"github.com/ethpandaops/go-eth2-client/spec/phase0"
 	"github.com/sirupsen/logrus"
 
+	"github.com/ethpandaops/buildoor/pkg/chain"
 	"github.com/ethpandaops/buildoor/pkg/db"
 	"github.com/ethpandaops/buildoor/pkg/memstore"
 )
@@ -40,6 +42,13 @@ type SlotActionsStore struct {
 	// is intentionally a prune-plus-put transaction at this layer.
 	mu    sync.RWMutex
 	store *memstore.Store[phase0.Slot, *SlotAction]
+
+	prunerMu     sync.Mutex
+	prunerCancel context.CancelFunc
+	prunerWG     sync.WaitGroup
+
+	callbackMu sync.RWMutex
+	onChange   func()
 }
 
 // SlotActionCodec translates the slot-action store's entries to their
@@ -73,9 +82,52 @@ func (s *SlotActionsStore) SetPersistence(ctx context.Context, stateDB *db.Datab
 		log.WithField("component", "slot-actions-store"))
 }
 
-// Stop flushes pending changes and stops the persistence flush loop. No-op
-// when no persistence is attached.
+// StartPruning removes expired actions as the connected chain advances. The
+// timer is aligned to the next slot boundary rather than polling, and the
+// initial prune clears stale entries rehydrated from persistence.
+func (s *SlotActionsStore) StartPruning(ctx context.Context, chainSvc chain.Service) {
+	if chainSvc == nil {
+		return
+	}
+
+	s.prunerMu.Lock()
+	defer s.prunerMu.Unlock()
+
+	if s.prunerCancel != nil {
+		return
+	}
+
+	prunerCtx, cancel := context.WithCancel(ctx)
+	s.prunerCancel = cancel
+	s.prunerWG.Add(1)
+
+	go s.runPruner(prunerCtx, chainSvc)
+}
+
+// SetChangeCallback registers a callback for background expiry changes. The
+// Web UI uses it to broadcast a fresh config snapshot after pruning. Passing
+// nil clears the callback.
+func (s *SlotActionsStore) SetChangeCallback(callback func()) {
+	s.callbackMu.Lock()
+	defer s.callbackMu.Unlock()
+
+	s.onChange = callback
+}
+
+// Stop stops background pruning, flushes pending changes, and stops the
+// persistence flush loop. No-op when neither service was started.
 func (s *SlotActionsStore) Stop() {
+	s.prunerMu.Lock()
+	cancel := s.prunerCancel
+	s.prunerCancel = nil
+	s.prunerMu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+
+	s.prunerWG.Wait()
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -137,15 +189,67 @@ func (s *SlotActionsStore) snapshotLocked() map[phase0.Slot]*SlotAction {
 }
 
 // PruneBefore drops every action whose slot is older than currentSlot (the
-// current slot's action is kept while the slot is in flight). Used to clear
-// stale entries rehydrated from a previous run.
-func (s *SlotActionsStore) PruneBefore(currentSlot phase0.Slot) {
+// current slot's action is kept while the slot is in flight). It returns the
+// number removed and notifies the change callback after releasing store locks.
+func (s *SlotActionsStore) PruneBefore(currentSlot phase0.Slot) int {
 	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	s.store.Prune(func(slot phase0.Slot) bool {
+	pruned := s.store.Prune(func(slot phase0.Slot) bool {
 		return slot < currentSlot
 	})
+	s.mu.Unlock()
+
+	if pruned > 0 {
+		s.notifyChanged()
+	}
+
+	return pruned
+}
+
+func (s *SlotActionsStore) runPruner(ctx context.Context, chainSvc chain.Service) {
+	defer s.prunerWG.Done()
+
+	for {
+		currentSlot := chainSvc.GetCurrentSlot()
+		s.PruneBefore(currentSlot)
+
+		// A max-value slot cannot have a representable successor. Keep the
+		// pruner dormant until shutdown instead of wrapping to genesis.
+		if currentSlot == ^phase0.Slot(0) {
+			<-ctx.Done()
+			return
+		}
+
+		nextSlotStart := chainSvc.SlotToTime(currentSlot + 1)
+		wait := time.Until(nextSlotStart)
+		if wait <= 0 {
+			// Protect against a temporarily inconsistent clock/service view.
+			wait = time.Millisecond
+		}
+
+		timer := time.NewTimer(wait)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+
+			return
+		case <-timer.C:
+		}
+	}
+}
+
+func (s *SlotActionsStore) notifyChanged() {
+	s.callbackMu.RLock()
+	callback := s.onChange
+	s.callbackMu.RUnlock()
+
+	if callback != nil {
+		callback()
+	}
 }
 
 // EncodeKey encodes a slot as its decimal string form.

--- a/pkg/payload_bidder/slot_actions.go
+++ b/pkg/payload_bidder/slot_actions.go
@@ -1,0 +1,183 @@
+package payload_bidder
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"sync"
+
+	"github.com/ethpandaops/go-eth2-client/spec/phase0"
+	"github.com/sirupsen/logrus"
+
+	"github.com/ethpandaops/buildoor/pkg/db"
+	"github.com/ethpandaops/buildoor/pkg/memstore"
+)
+
+// RevealActionWithhold instructs the reveal service to intentionally NOT
+// publish the payload envelope for a configured slot (deterministic fault
+// injection for Gloas/ePBS testing). Building and bidding are unaffected.
+const RevealActionWithhold = "withhold"
+
+// SlotActionsNamespace is the kv_store namespace holding the persisted
+// per-slot actions.
+const SlotActionsNamespace = "slot_actions"
+
+// SlotAction is the set of fault-injection actions configured for one exact
+// slot. The JSON tags are the wire shape of the config API and the persisted
+// kv_store value.
+type SlotAction struct {
+	Reveal string `json:"reveal,omitempty"` // only RevealActionWithhold today
+}
+
+// SlotActionsStore holds the per-slot fault-injection actions configured via
+// the runtime config API. Writes replace the complete set of pending FUTURE
+// actions; an action whose slot has started is immutable and is only dropped
+// once it is stale. The reveal service reads it on every schedule decision.
+type SlotActionsStore struct {
+	// mu makes a complete replacement atomic to readers and to concurrent API
+	// requests. memstore protects each individual operation, but ReplaceFuture
+	// is intentionally a prune-plus-put transaction at this layer.
+	mu    sync.RWMutex
+	store *memstore.Store[phase0.Slot, *SlotAction]
+}
+
+// SlotActionCodec translates the slot-action store's entries to their
+// persisted form: decimal slot string keys, JSON-encoded values.
+type SlotActionCodec struct{}
+
+var _ db.KVCodec[phase0.Slot, *SlotAction] = SlotActionCodec{}
+
+// NewSlotActionsStore creates an empty SlotActionsStore.
+func NewSlotActionsStore() *SlotActionsStore {
+	return &SlotActionsStore{
+		store: memstore.New[phase0.Slot, *SlotAction](),
+	}
+}
+
+// SetPersistence attaches the optional state-db so configured actions survive
+// restarts: previously persisted entries are loaded and future changes are
+// flushed (buffered) into the store's kv_store namespace. Call Stop before
+// the state-db closes.
+func (s *SlotActionsStore) SetPersistence(ctx context.Context, stateDB *db.Database,
+	log logrus.FieldLogger) {
+	if stateDB == nil {
+		return
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.store.SetPersistence(ctx,
+		db.NewKVPersistence(stateDB, SlotActionsNamespace, SlotActionCodec{}),
+		log.WithField("component", "slot-actions-store"))
+}
+
+// Stop flushes pending changes and stops the persistence flush loop. No-op
+// when no persistence is attached.
+func (s *SlotActionsStore) Stop() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.store.Stop()
+}
+
+// Get returns the action configured for a slot and whether one was found.
+func (s *SlotActionsStore) Get(slot phase0.Slot) (*SlotAction, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.store.Get(slot)
+}
+
+// ReplaceFuture replaces the complete set of pending future actions with the
+// given set (an empty map clears it). Entries whose slot has started
+// (slot <= currentSlot) are immutable: existing ones are kept, new ones are
+// never stored (callers validate this; the check here is defensive). Stale
+// entries (slot < currentSlot) are pruned. Returns the effective stored
+// snapshot.
+func (s *SlotActionsStore) ReplaceFuture(actions map[phase0.Slot]*SlotAction,
+	currentSlot phase0.Slot) map[phase0.Slot]*SlotAction {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.store.Prune(func(slot phase0.Slot) bool {
+		if slot < currentSlot {
+			return true // stale
+		}
+
+		if slot == currentSlot {
+			return false // in-flight, immutable
+		}
+
+		_, keep := actions[slot]
+
+		return !keep // future entry not part of the new set
+	})
+
+	for slot, action := range actions {
+		if slot > currentSlot && action != nil {
+			s.store.Put(slot, action)
+		}
+	}
+
+	return s.snapshotLocked()
+}
+
+// Snapshot returns a copy of all stored actions keyed by slot.
+func (s *SlotActionsStore) Snapshot() map[phase0.Slot]*SlotAction {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.snapshotLocked()
+}
+
+func (s *SlotActionsStore) snapshotLocked() map[phase0.Slot]*SlotAction {
+	return s.store.Entries()
+}
+
+// PruneBefore drops every action whose slot is older than currentSlot (the
+// current slot's action is kept while the slot is in flight). Used to clear
+// stale entries rehydrated from a previous run.
+func (s *SlotActionsStore) PruneBefore(currentSlot phase0.Slot) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.store.Prune(func(slot phase0.Slot) bool {
+		return slot < currentSlot
+	})
+}
+
+// EncodeKey encodes a slot as its decimal string form.
+func (SlotActionCodec) EncodeKey(slot phase0.Slot) string {
+	return strconv.FormatUint(uint64(slot), 10)
+}
+
+// DecodeKey parses a decimal slot string.
+func (SlotActionCodec) DecodeKey(key string) (phase0.Slot, error) {
+	slot, err := strconv.ParseUint(key, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid slot action key %q: %w", key, err)
+	}
+
+	return phase0.Slot(slot), nil
+}
+
+// EncodeValue JSON-encodes a slot action.
+func (SlotActionCodec) EncodeValue(action *SlotAction) ([]byte, error) {
+	if action == nil {
+		return nil, fmt.Errorf("cannot encode nil slot action")
+	}
+
+	return json.Marshal(action)
+}
+
+// DecodeValue JSON-decodes a slot action.
+func (SlotActionCodec) DecodeValue(value []byte) (*SlotAction, error) {
+	action := &SlotAction{}
+	if err := json.Unmarshal(value, action); err != nil {
+		return nil, fmt.Errorf("failed to decode slot action: %w", err)
+	}
+
+	return action, nil
+}

--- a/pkg/payload_bidder/slot_actions_test.go
+++ b/pkg/payload_bidder/slot_actions_test.go
@@ -1,0 +1,148 @@
+package payload_bidder
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/ethpandaops/go-eth2-client/spec/phase0"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethpandaops/buildoor/pkg/db"
+)
+
+func withhold() *SlotAction {
+	return &SlotAction{Reveal: RevealActionWithhold}
+}
+
+func TestSlotActionsStore_ReplaceFuture(t *testing.T) {
+	store := NewSlotActionsStore()
+
+	// Seed: 5 (past), 10 (current), 15 and 20 (future) from slot 0's view.
+	store.ReplaceFuture(map[phase0.Slot]*SlotAction{
+		5: withhold(), 10: withhold(), 15: withhold(), 20: withhold(),
+	}, 0)
+	require.Equal(t, 4, len(store.Snapshot()))
+
+	// Replace at current slot 10: 5 is stale (pruned), 10 has started
+	// (immutable, kept), 15 is dropped (not in the new set), 20 is kept,
+	// 25 is added.
+	effective := store.ReplaceFuture(map[phase0.Slot]*SlotAction{
+		20: withhold(), 25: withhold(),
+	}, 10)
+
+	assert.Equal(t, map[phase0.Slot]*SlotAction{
+		10: withhold(), 20: withhold(), 25: withhold(),
+	}, effective)
+	assert.Equal(t, effective, store.Snapshot())
+}
+
+func TestSlotActionsStore_ReplaceFutureClears(t *testing.T) {
+	store := NewSlotActionsStore()
+	store.ReplaceFuture(map[phase0.Slot]*SlotAction{15: withhold(), 20: withhold()}, 10)
+
+	// An empty set clears all pending future actions.
+	effective := store.ReplaceFuture(map[phase0.Slot]*SlotAction{}, 10)
+	assert.Empty(t, effective)
+	assert.Empty(t, store.Snapshot())
+}
+
+func TestSlotActionsStore_ReplaceFutureKeepsStartedSlot(t *testing.T) {
+	store := NewSlotActionsStore()
+	store.ReplaceFuture(map[phase0.Slot]*SlotAction{15: withhold()}, 10)
+
+	// Slot 15 has started: clearing must not remove it (slot-boundary lock).
+	effective := store.ReplaceFuture(map[phase0.Slot]*SlotAction{}, 15)
+	require.Len(t, effective, 1)
+	action, ok := store.Get(15)
+	require.True(t, ok)
+	assert.Equal(t, RevealActionWithhold, action.Reveal)
+}
+
+func TestSlotActionsStore_ReplaceFutureSkipsNonFutureEntries(t *testing.T) {
+	store := NewSlotActionsStore()
+
+	// Defensive: entries at or before the current slot are never stored.
+	effective := store.ReplaceFuture(map[phase0.Slot]*SlotAction{
+		5: withhold(), 10: withhold(), 15: withhold(),
+	}, 10)
+
+	assert.Equal(t, map[phase0.Slot]*SlotAction{15: withhold()}, effective)
+}
+
+func TestSlotActionsStore_PruneBefore(t *testing.T) {
+	store := NewSlotActionsStore()
+	store.ReplaceFuture(map[phase0.Slot]*SlotAction{5: withhold(), 10: withhold(), 15: withhold()}, 0)
+
+	// The current slot's action is kept while in flight; older ones drop.
+	store.PruneBefore(10)
+
+	assert.Equal(t, map[phase0.Slot]*SlotAction{
+		10: withhold(), 15: withhold(),
+	}, store.Snapshot())
+}
+
+func TestSlotActionCodec_RoundTrip(t *testing.T) {
+	codec := SlotActionCodec{}
+
+	key := codec.EncodeKey(384)
+	assert.Equal(t, "384", key)
+
+	slot, err := codec.DecodeKey(key)
+	require.NoError(t, err)
+	assert.Equal(t, phase0.Slot(384), slot)
+
+	_, err = codec.DecodeKey("not-a-slot")
+	require.Error(t, err)
+
+	value, err := codec.EncodeValue(withhold())
+	require.NoError(t, err)
+
+	decoded, err := codec.DecodeValue(value)
+	require.NoError(t, err)
+	assert.Equal(t, RevealActionWithhold, decoded.Reveal)
+
+	_, err = codec.EncodeValue(nil)
+	require.Error(t, err)
+}
+
+func TestSlotActionsStore_Persistence(t *testing.T) {
+	logger, _ := newHookedLogger()
+
+	stateDB := db.NewDatabase(&db.Config{File: filepath.Join(t.TempDir(), "state.db")}, logger)
+	require.NoError(t, stateDB.Init())
+
+	defer func() {
+		require.NoError(t, stateDB.Close())
+	}()
+
+	store := NewSlotActionsStore()
+	store.SetPersistence(t.Context(), stateDB, logger)
+	store.ReplaceFuture(map[phase0.Slot]*SlotAction{384: withhold(), 416: withhold()}, 10)
+
+	// Stop flushes; the actions land in the kv_store's slot_actions namespace.
+	store.Stop()
+
+	persisted, err := db.NewKVPersistence(stateDB, SlotActionsNamespace, SlotActionCodec{}).Load()
+	require.NoError(t, err)
+	require.Len(t, persisted, 2)
+	assert.Equal(t, RevealActionWithhold, persisted[phase0.Slot(384)].Reveal)
+
+	// A fresh store rehydrates on persistence attach; stale entries are
+	// pruned like the startup sequence does, and the deletions persist.
+	rehydrated := NewSlotActionsStore()
+	rehydrated.SetPersistence(t.Context(), stateDB, logger)
+	rehydrated.PruneBefore(400)
+
+	action, ok := rehydrated.Get(416)
+	require.True(t, ok)
+	assert.Equal(t, RevealActionWithhold, action.Reveal)
+	_, ok = rehydrated.Get(384)
+	assert.False(t, ok, "stale entries must be pruned after rehydration")
+
+	rehydrated.Stop()
+
+	persisted, err = db.NewKVPersistence(stateDB, SlotActionsNamespace, SlotActionCodec{}).Load()
+	require.NoError(t, err)
+	require.Len(t, persisted, 1, "the prune must propagate to the kv_store")
+}

--- a/pkg/payload_bidder/slot_actions_test.go
+++ b/pkg/payload_bidder/slot_actions_test.go
@@ -1,8 +1,10 @@
 package payload_bidder
 
 import (
+	"context"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/ethpandaops/go-eth2-client/spec/phase0"
 	"github.com/stretchr/testify/assert"
@@ -80,6 +82,48 @@ func TestSlotActionsStore_PruneBefore(t *testing.T) {
 	assert.Equal(t, map[phase0.Slot]*SlotAction{
 		10: withhold(), 15: withhold(),
 	}, store.Snapshot())
+}
+
+func TestSlotActionsStore_PrunesAsSlotsAdvance(t *testing.T) {
+	const slotDuration = 20 * time.Millisecond
+
+	genesisTime := time.Now().Add(-10 * slotDuration)
+	chainSvc := &stubChainService{
+		genesisTime:  genesisTime,
+		slotDuration: slotDuration,
+		currentSlot: func() phase0.Slot {
+			return phase0.Slot(time.Since(genesisTime) / slotDuration)
+		},
+	}
+	startSlot := chainSvc.GetCurrentSlot()
+
+	store := NewSlotActionsStore()
+	store.ReplaceFuture(map[phase0.Slot]*SlotAction{
+		startSlot:     withhold(),
+		startSlot + 1: withhold(),
+		startSlot + 2: withhold(),
+	}, startSlot-1)
+
+	changed := make(chan struct{}, 1)
+	store.SetChangeCallback(func() {
+		select {
+		case changed <- struct{}{}:
+		default:
+		}
+	})
+	store.StartPruning(context.Background(), chainSvc)
+	defer store.Stop()
+
+	require.Eventually(t, func() bool {
+		_, exists := store.Get(startSlot)
+		return !exists
+	}, time.Second, 5*time.Millisecond)
+
+	select {
+	case <-changed:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for slot-action expiry notification")
+	}
 }
 
 func TestSlotActionCodec_RoundTrip(t *testing.T) {

--- a/pkg/webui/handlers/api/api.go
+++ b/pkg/webui/handlers/api/api.go
@@ -374,10 +374,18 @@ func (h *APIHandler) UpdateEPBS(w http.ResponseWriter, r *http.Request) {
 		updates[config.KeyEPBSBidSubsidy] = mustJSON(*req.BidSubsidy)
 	}
 
-	// Re-sample at the commit point. A request can arrive just before a slot
-	// boundary and finish decoding/validating just after it; applying with the
-	// earlier slot would allow a now-current action to be added or changed.
+	if !h.applySettings(w, r, token, "config.epbs", req, updates) {
+		return
+	}
+
+	resp := map[string]any{"status": "updated"}
+
+	// Apply the validated slot actions (replace-the-future-set semantics) and
+	// echo the effective stored set so callers can archive what was accepted.
 	if req.SlotActions != nil {
+		// Re-sample immediately before replacement, after scalar settings have
+		// been applied. SetMany can span a slot boundary, and using the earlier
+		// sample would allow a now-current action to be inserted or cleared.
 		latestSlot := h.chainSvc.GetCurrentSlot()
 		if latestSlot != currentSlot {
 			parsed, err := parseSlotActions(req.SlotActions, latestSlot)
@@ -389,17 +397,7 @@ func (h *APIHandler) UpdateEPBS(w http.ResponseWriter, r *http.Request) {
 			currentSlot = latestSlot
 			slotActions = parsed
 		}
-	}
 
-	if !h.applySettings(w, r, token, "config.epbs", req, updates) {
-		return
-	}
-
-	resp := map[string]any{"status": "updated"}
-
-	// Apply the validated slot actions (replace-the-future-set semantics) and
-	// echo the effective stored set so callers can archive what was accepted.
-	if req.SlotActions != nil {
 		effective := h.slotActions.ReplaceFuture(slotActions, currentSlot)
 		h.audit(r, token, "config.epbs.slot_actions", "", req.SlotActions, "ok")
 		resp["slot_actions"] = formatSlotActions(effective)

--- a/pkg/webui/handlers/api/api.go
+++ b/pkg/webui/handlers/api/api.go
@@ -5,7 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sort"
 	"strconv"
+
+	"github.com/ethpandaops/go-eth2-client/spec/phase0"
 
 	"github.com/ethpandaops/buildoor/pkg/config"
 	"github.com/ethpandaops/buildoor/pkg/p2p_bidder"
@@ -65,6 +68,12 @@ type UpdateEPBSRequest struct {
 	BidInterval       *int64  `json:"bid_interval,omitempty"`
 	PayloadBuildDelay *int64  `json:"payload_build_delay,omitempty"`
 	BidSubsidy        *uint64 `json:"bid_subsidy,omitempty"`
+
+	// SlotActions, when present, replaces the complete set of pending FUTURE
+	// per-slot actions (an empty object clears it); actions whose slot has
+	// started are immutable. Keys are decimal slot numbers strictly in the
+	// future; the only supported action is {"reveal": "withhold"}.
+	SlotActions map[string]map[string]string `json:"slot_actions,omitempty"`
 }
 
 // UpdateBuilderConfigRequest is the request for updating shared builder config.
@@ -213,9 +222,7 @@ func (h *APIHandler) GetStats(w http.ResponseWriter, _ *http.Request) {
 // @Router /api/config [get]
 func (h *APIHandler) GetConfig(w http.ResponseWriter, _ *http.Request) {
 	cfg := h.builderSvc.GetConfig()
-	// Redact sensitive fields before returning
-	out := configToMap(cfg)
-	writeJSON(w, http.StatusOK, out)
+	writeJSON(w, http.StatusOK, configWithSlotActions(cfg, h.slotActions))
 }
 
 // UpdateSchedule godoc
@@ -274,13 +281,15 @@ func (h *APIHandler) UpdateSchedule(w http.ResponseWriter, r *http.Request) {
 // @Id updateEPBS
 // @Summary Update EPBS configuration
 // @Tags Config
-// @Description Updates the EPBS (enshrined PBS) configuration including timing and bid
-// @Description parameters. Requires authentication.
+// @Description Updates the EPBS (enshrined PBS) configuration including timing, bid
+// @Description parameters, and per-slot reveal actions (slot_actions replaces the pending
+// @Description future set; only future slots and the "withhold" reveal action are
+// @Description accepted). Requires authentication.
 // @Accept json
 // @Produce json
 // @Param Authorization header string true "Bearer token"
 // @Param request body UpdateEPBSRequest true "EPBS configuration"
-// @Success 200 {object} map[string]string "Success"
+// @Success 200 {object} map[string]interface{} "Success (includes the effective stored slot_actions)"
 // @Failure 400 {object} map[string]string "Bad Request"
 // @Failure 401 {object} map[string]string "Unauthorized"
 // @Failure 500 {object} map[string]string "Server Error"
@@ -296,6 +305,36 @@ func (h *APIHandler) UpdateEPBS(w http.ResponseWriter, r *http.Request) {
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid request body")
 		return
+	}
+
+	// Validate slot_actions fully before applying anything (scalar settings
+	// included) so a bad request never half-applies.
+	var (
+		slotActions map[phase0.Slot]*payload_bidder.SlotAction
+		currentSlot phase0.Slot
+	)
+
+	if req.SlotActions != nil {
+		if h.slotActions == nil {
+			writeError(w, http.StatusBadRequest,
+				"slot_actions: not supported: Gloas/ePBS is not scheduled on this network")
+			return
+		}
+
+		if h.chainSvc == nil {
+			writeError(w, http.StatusServiceUnavailable, "slot_actions: chain service unavailable")
+			return
+		}
+
+		currentSlot = h.chainSvc.GetCurrentSlot()
+
+		parsed, err := parseSlotActions(req.SlotActions, currentSlot)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+
+		slotActions = parsed
 	}
 
 	updates := map[string]json.RawMessage{}
@@ -335,11 +374,44 @@ func (h *APIHandler) UpdateEPBS(w http.ResponseWriter, r *http.Request) {
 		updates[config.KeyEPBSBidSubsidy] = mustJSON(*req.BidSubsidy)
 	}
 
+	// Re-sample at the commit point. A request can arrive just before a slot
+	// boundary and finish decoding/validating just after it; applying with the
+	// earlier slot would allow a now-current action to be added or changed.
+	if req.SlotActions != nil {
+		latestSlot := h.chainSvc.GetCurrentSlot()
+		if latestSlot != currentSlot {
+			parsed, err := parseSlotActions(req.SlotActions, latestSlot)
+			if err != nil {
+				writeError(w, http.StatusBadRequest, err.Error())
+				return
+			}
+
+			currentSlot = latestSlot
+			slotActions = parsed
+		}
+	}
+
 	if !h.applySettings(w, r, token, "config.epbs", req, updates) {
 		return
 	}
 
-	writeJSON(w, http.StatusOK, map[string]string{"status": "updated"})
+	resp := map[string]any{"status": "updated"}
+
+	// Apply the validated slot actions (replace-the-future-set semantics) and
+	// echo the effective stored set so callers can archive what was accepted.
+	if req.SlotActions != nil {
+		effective := h.slotActions.ReplaceFuture(slotActions, currentSlot)
+		h.audit(r, token, "config.epbs.slot_actions", "", req.SlotActions, "ok")
+		resp["slot_actions"] = formatSlotActions(effective)
+
+		if h.eventStreamMgr != nil {
+			h.eventStreamMgr.BroadcastConfigUpdate()
+		}
+	} else if h.slotActions != nil {
+		resp["slot_actions"] = formatSlotActions(h.slotActions.Snapshot())
+	}
+
+	writeJSON(w, http.StatusOK, resp)
 }
 
 // GetLifecycleStatus godoc
@@ -890,6 +962,74 @@ func (h *APIHandler) GetBuilderPreferences(w http.ResponseWriter, _ *http.Reques
 	writeJSON(w, http.StatusOK, BuilderPreferencesResponse{Preferences: result})
 }
 
+// parseSlotActions validates a slot_actions request map: decimal slot keys
+// strictly in the future and only the {"reveal": "withhold"} action. Keys are
+// checked in sorted order so rejections are deterministic.
+func parseSlotActions(raw map[string]map[string]string,
+	currentSlot phase0.Slot) (map[phase0.Slot]*payload_bidder.SlotAction, error) {
+	parsed := make(map[phase0.Slot]*payload_bidder.SlotAction, len(raw))
+
+	keys := make([]string, 0, len(raw))
+	for key := range raw {
+		keys = append(keys, key)
+	}
+
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		slotNum, err := strconv.ParseUint(key, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("slot_actions: invalid slot key %q: must be a decimal slot number", key)
+		}
+
+		slot := phase0.Slot(slotNum)
+
+		action := raw[key]
+		if len(action) == 0 {
+			return nil, fmt.Errorf("slot_actions: no action specified for slot %d", slot)
+		}
+
+		actionKeys := make([]string, 0, len(action))
+		for actionKey := range action {
+			actionKeys = append(actionKeys, actionKey)
+		}
+
+		sort.Strings(actionKeys)
+
+		for _, actionKey := range actionKeys {
+			if actionKey != "reveal" {
+				return nil, fmt.Errorf("slot_actions: unknown action %q for slot %d (supported: \"reveal\")",
+					actionKey, slot)
+			}
+
+			if action[actionKey] != payload_bidder.RevealActionWithhold {
+				return nil, fmt.Errorf("slot_actions: unknown reveal action %q for slot %d (supported: %q)",
+					action[actionKey], slot, payload_bidder.RevealActionWithhold)
+			}
+		}
+
+		if slot <= currentSlot {
+			return nil, fmt.Errorf("slot_actions: slot %d is not in the future (current slot %d)",
+				slot, currentSlot)
+		}
+
+		parsed[slot] = &payload_bidder.SlotAction{Reveal: payload_bidder.RevealActionWithhold}
+	}
+
+	return parsed, nil
+}
+
+// formatSlotActions renders a stored slot-action snapshot with decimal string
+// keys (the JSON wire shape).
+func formatSlotActions(actions map[phase0.Slot]*payload_bidder.SlotAction) map[string]*payload_bidder.SlotAction {
+	out := make(map[string]*payload_bidder.SlotAction, len(actions))
+	for slot, action := range actions {
+		out[strconv.FormatUint(uint64(slot), 10)] = action
+	}
+
+	return out
+}
+
 // configToMap returns the config as a map with sensitive fields redacted.
 func configToMap(cfg *config.Config) map[string]any {
 	if cfg == nil {
@@ -912,6 +1052,23 @@ func configToMap(cfg *config.Config) map[string]any {
 	redact("wallet_privkey")
 	redact("el_jwt_secret")
 	return m
+}
+
+// configWithSlotActions returns the redacted runtime config plus the per-slot
+// actions kept outside config.Config. REST and SSE both use this shape so the
+// WebUI always reflects an API update, including after reconnecting.
+func configWithSlotActions(cfg *config.Config,
+	slotActions *payload_bidder.SlotActionsStore) map[string]any {
+	out := configToMap(cfg)
+	if slotActions == nil || out == nil {
+		return out
+	}
+
+	if epbsMap, ok := out["epbs"].(map[string]any); ok {
+		epbsMap["slot_actions"] = formatSlotActions(slotActions.Snapshot())
+	}
+
+	return out
 }
 
 // writeJSON writes a JSON response.

--- a/pkg/webui/handlers/api/builder_preferences_test.go
+++ b/pkg/webui/handlers/api/builder_preferences_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestGetBuilderPreferences_NotEnabled(t *testing.T) {
 	// No builder API service wired → 404.
-	h := NewAPIHandler(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	h := NewAPIHandler(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/buildoor/builder-preferences", nil)
 	rec := httptest.NewRecorder()
@@ -37,7 +37,7 @@ func TestGetBuilderPreferences_ReturnsEntries(t *testing.T) {
 
 	// builderSvc (4th arg) nil so the event stream manager does not start;
 	// srv is passed as builderAPISvc (9th arg).
-	h := NewAPIHandler(nil, nil, nil, nil, nil, nil, nil, nil, srv, nil, nil, nil, nil, nil)
+	h := NewAPIHandler(nil, nil, nil, nil, nil, nil, nil, nil, srv, nil, nil, nil, nil, nil, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/buildoor/builder-preferences", nil)
 	rec := httptest.NewRecorder()

--- a/pkg/webui/handlers/api/events.go
+++ b/pkg/webui/handlers/api/events.go
@@ -559,6 +559,10 @@ func (m *EventStreamManager) Start() {
 
 // Stop stops the event stream manager.
 func (m *EventStreamManager) Stop() {
+	if m.slotActions != nil {
+		m.slotActions.SetChangeCallback(nil)
+	}
+
 	m.cancel()
 	m.wg.Wait()
 }

--- a/pkg/webui/handlers/api/events.go
+++ b/pkg/webui/handlers/api/events.go
@@ -52,6 +52,7 @@ const (
 	EventTypeServiceStatus               EventType = "service_status"
 	EventTypeLifecycle                   EventType = "lifecycle"
 	EventTypeBidIncluded                 EventType = "bid_included"
+	EventTypeIntentionallyWithheld       EventType = "intentionally_withheld"
 )
 
 // StreamEvent is a wrapper for all event types sent to clients.
@@ -125,6 +126,18 @@ type HeadReceivedEvent struct {
 	Slot       uint64 `json:"slot"`
 	BlockRoot  string `json:"block_root"`
 	ReceivedAt int64  `json:"received_at"`
+}
+
+// WithheldStreamEvent is sent when a reveal is intentionally withheld for a
+// slot with a configured "withhold" action — the receipt that the configured
+// fault was applied.
+type WithheldStreamEvent struct {
+	Slot          uint64 `json:"slot"`
+	BuilderIndex  uint64 `json:"builder_index"`
+	BuilderPubkey string `json:"builder_pubkey"`
+	Action        string `json:"action"`
+	Status        string `json:"status"`
+	Timestamp     int64  `json:"timestamp"`
 }
 
 // RevealStreamEvent is sent when we submit or skip a reveal (one per attempt).
@@ -294,6 +307,7 @@ type EventStreamManager struct {
 	revealSvc        *payload_bidder.RevealService    // Optional shared reveal service (Gloas+)
 	inclusionTracker *payload_bidder.InclusionTracker // Optional shared inclusion tracker
 	payments         *payload_bidder.PaymentTracker   // Optional shared payment tracker (Gloas+)
+	slotActions      *payload_bidder.SlotActionsStore // Optional exact-slot reveal actions (Gloas+)
 
 	clients map[chan *StreamEvent]struct{}
 	mu      sync.RWMutex
@@ -328,6 +342,7 @@ func NewEventStreamManager(
 	revealSvc *payload_bidder.RevealService,
 	inclusionTracker *payload_bidder.InclusionTracker,
 	payments *payload_bidder.PaymentTracker,
+	slotActions *payload_bidder.SlotActionsStore,
 ) *EventStreamManager {
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -340,6 +355,7 @@ func NewEventStreamManager(
 		revealSvc:        revealSvc,
 		inclusionTracker: inclusionTracker,
 		payments:         payments,
+		slotActions:      slotActions,
 		clients:          make(map[chan *StreamEvent]struct{}, 8),
 		ctx:              ctx,
 		cancel:           cancel,
@@ -498,7 +514,11 @@ func (m *EventStreamManager) Start() {
 					continue
 				}
 
-				m.BroadcastReveal(event)
+				if event.Withheld {
+					m.BroadcastWithheld(event)
+				} else {
+					m.BroadcastReveal(event)
+				}
 
 			case event, ok := <-bidIncludedChan:
 				if !ok {
@@ -1076,7 +1096,7 @@ func (m *EventStreamManager) SendInitialState(ctx context.Context, ch chan *Stre
 	if !send(&StreamEvent{
 		Type:      EventTypeConfig,
 		Timestamp: time.Now().UnixMilli(),
-		Data:      m.builderSvc.GetConfig(),
+		Data:      configWithSlotActions(m.builderSvc.GetConfig(), m.slotActions),
 	}) {
 		return
 	}
@@ -1315,13 +1335,33 @@ func (m *EventStreamManager) BroadcastReveal(event *payload_bidder.RevealResult)
 	m.broadcastSlotState(event.Slot)
 }
 
+// BroadcastWithheld broadcasts an intentionally_withheld event: the receipt
+// that a configured per-slot "withhold" reveal action was applied.
+func (m *EventStreamManager) BroadcastWithheld(event *payload_bidder.RevealResult) {
+	now := time.Now().UnixMilli()
+
+	m.Broadcast(&StreamEvent{
+		Type:      EventTypeIntentionallyWithheld,
+		Timestamp: now,
+		Data: WithheldStreamEvent{
+			Slot:          uint64(event.Slot),
+			BuilderIndex:  event.BuilderIndex,
+			BuilderPubkey: event.BuilderPubkey,
+			Action:        event.Action,
+			Status:        "intentionally_withheld",
+			Timestamp:     now,
+		},
+	})
+
+	m.broadcastSlotState(event.Slot)
+}
+
 // BroadcastConfigUpdate broadcasts a config update event.
 func (m *EventStreamManager) BroadcastConfigUpdate() {
-	cfg := m.builderSvc.GetConfig()
 	m.Broadcast(&StreamEvent{
 		Type:      EventTypeConfig,
 		Timestamp: time.Now().UnixMilli(),
-		Data:      cfg,
+		Data:      configWithSlotActions(m.builderSvc.GetConfig(), m.slotActions),
 	})
 }
 

--- a/pkg/webui/handlers/api/handler.go
+++ b/pkg/webui/handlers/api/handler.go
@@ -35,6 +35,7 @@ type APIHandler struct {
 	revealSvc        *payload_bidder.RevealService    // May be nil (Gloas not scheduled)
 	inclusionTracker *payload_bidder.InclusionTracker // May be nil
 	payments         *payload_bidder.PaymentTracker   // May be nil (Gloas not scheduled)
+	slotActions      *payload_bidder.SlotActionsStore // May be nil (Gloas not scheduled)
 }
 
 // NewAPIHandler creates a new API handler.
@@ -53,6 +54,7 @@ func NewAPIHandler(
 	revealSvc *payload_bidder.RevealService,
 	inclusionTracker *payload_bidder.InclusionTracker,
 	payments *payload_bidder.PaymentTracker,
+	slotActions *payload_bidder.SlotActionsStore,
 ) *APIHandler {
 	h := &APIHandler{
 		authHandler:    authHandler,
@@ -70,13 +72,14 @@ func NewAPIHandler(
 		revealSvc:        revealSvc,
 		inclusionTracker: inclusionTracker,
 		payments:         payments,
+		slotActions:      slotActions,
 	}
 
 	// Create and start event stream manager
 	if builderSvc != nil {
 		h.eventStreamMgr = NewEventStreamManager(
 			builderSvc, epbsSvc, lifecycleMgr, chainSvc,
-			builderAPISvc, revealSvc, inclusionTracker, payments,
+			builderAPISvc, revealSvc, inclusionTracker, payments, slotActions,
 		)
 		h.eventStreamMgr.Start()
 	}

--- a/pkg/webui/handlers/api/handler.go
+++ b/pkg/webui/handlers/api/handler.go
@@ -81,6 +81,10 @@ func NewAPIHandler(
 			builderSvc, epbsSvc, lifecycleMgr, chainSvc,
 			builderAPISvc, revealSvc, inclusionTracker, payments, slotActions,
 		)
+		if slotActions != nil {
+			slotActions.SetChangeCallback(h.eventStreamMgr.BroadcastConfigUpdate)
+		}
+
 		h.eventStreamMgr.Start()
 	}
 

--- a/pkg/webui/handlers/api/slot_actions_test.go
+++ b/pkg/webui/handlers/api/slot_actions_test.go
@@ -10,11 +10,13 @@ import (
 	"time"
 
 	"github.com/ethpandaops/go-eth2-client/spec/phase0"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethpandaops/buildoor/pkg/chain"
 	"github.com/ethpandaops/buildoor/pkg/config"
+	"github.com/ethpandaops/buildoor/pkg/db"
 	"github.com/ethpandaops/buildoor/pkg/payload_bidder"
 	"github.com/ethpandaops/buildoor/pkg/webui/handlers/auth"
 )
@@ -59,6 +61,25 @@ func newSlotActionsTestHandler(t *testing.T, currentSlot phase0.Slot,
 
 	return NewAPIHandler(authHandler, nil, nil, nil, nil, nil, chainSvc,
 		nil, nil, nil, nil, nil, nil, nil, store)
+}
+
+func attachSlotActionsTestSettings(t *testing.T, h *APIHandler) *config.Service {
+	t.Helper()
+
+	log := logrus.New()
+	stateDB := db.NewDatabase(&db.Config{}, log)
+	require.NoError(t, stateDB.Init())
+	t.Cleanup(func() { require.NoError(t, stateDB.Close()) })
+
+	settingsSvc, err := config.NewService(
+		config.DefaultConfig(), config.DefaultConfig(), map[string]bool{}, stateDB, log,
+	)
+	require.NoError(t, err)
+
+	h.settingsSvc = settingsSvc
+	h.stateDB = stateDB
+
+	return settingsSvc
 }
 
 func postEPBS(t *testing.T, h *APIHandler, body string) (int, epbsUpdateResponse) {
@@ -130,6 +151,24 @@ func TestUpdateEPBS_SlotActionsRejectsBoundaryCrossing(t *testing.T) {
 	h.chainSvc.(*stubChainService).nextSlot = &started
 
 	code, resp := postEPBS(t, h, `{"slot_actions":{"15":{"reveal":"withhold"}}}`)
+	require.Equal(t, http.StatusBadRequest, code)
+	assert.Equal(t, "slot_actions: slot 15 is not in the future (current slot 15)", resp.Error)
+	assert.Empty(t, store.Snapshot())
+}
+
+func TestUpdateEPBS_SlotActionsRejectsBoundaryCrossingDuringSettingsApply(t *testing.T) {
+	store := payload_bidder.NewSlotActionsStore()
+	h := newSlotActionsTestHandler(t, 10, store)
+	settingsSvc := attachSlotActionsTestSettings(t, h)
+
+	// Advance the slot from a SetMany callback. This places the boundary after
+	// the handler's initial validation but before slot-action replacement.
+	settingsSvc.OnChange(func() {
+		h.chainSvc.(*stubChainService).currentSlot = 15
+	})
+
+	code, resp := postEPBS(t, h,
+		`{"reveal_time":1000,"slot_actions":{"15":{"reveal":"withhold"}}}`)
 	require.Equal(t, http.StatusBadRequest, code)
 	assert.Equal(t, "slot_actions: slot 15 is not in the future (current slot 15)", resp.Error)
 	assert.Empty(t, store.Snapshot())

--- a/pkg/webui/handlers/api/slot_actions_test.go
+++ b/pkg/webui/handlers/api/slot_actions_test.go
@@ -1,0 +1,293 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ethpandaops/go-eth2-client/spec/phase0"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethpandaops/buildoor/pkg/chain"
+	"github.com/ethpandaops/buildoor/pkg/config"
+	"github.com/ethpandaops/buildoor/pkg/payload_bidder"
+	"github.com/ethpandaops/buildoor/pkg/webui/handlers/auth"
+)
+
+// stubChainService fakes the current slot; every other chain.Service method
+// panics via the embedded nil interface (they must not be called here).
+type stubChainService struct {
+	chain.Service
+	currentSlot phase0.Slot
+	nextSlot    *phase0.Slot
+	calls       int
+}
+
+func (s *stubChainService) GetCurrentSlot() phase0.Slot {
+	s.calls++
+	if s.calls > 1 && s.nextSlot != nil {
+		return *s.nextSlot
+	}
+
+	return s.currentSlot
+}
+
+// epbsUpdateResponse decodes the UpdateEPBS response (success and error).
+type epbsUpdateResponse struct {
+	Status      string                                `json:"status"`
+	SlotActions map[string]*payload_bidder.SlotAction `json:"slot_actions"`
+	Error       string                                `json:"error"`
+}
+
+// newSlotActionsTestHandler builds an APIHandler in open-auth mode with a
+// fake current slot. builderSvc is nil so no event stream manager starts;
+// settingsSvc is unused because slot-action-only requests carry no scalar
+// updates (an empty update set is a no-op).
+func newSlotActionsTestHandler(t *testing.T, currentSlot phase0.Slot,
+	store *payload_bidder.SlotActionsStore) *APIHandler {
+	t.Helper()
+
+	authHandler, err := auth.NewAuthHandler(context.Background(), "")
+	require.NoError(t, err)
+
+	chainSvc := &stubChainService{currentSlot: currentSlot}
+
+	return NewAPIHandler(authHandler, nil, nil, nil, nil, nil, chainSvc,
+		nil, nil, nil, nil, nil, nil, nil, store)
+}
+
+func postEPBS(t *testing.T, h *APIHandler, body string) (int, epbsUpdateResponse) {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/config/epbs", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	h.UpdateEPBS(rec, req)
+
+	var resp epbsUpdateResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+
+	return rec.Code, resp
+}
+
+func TestUpdateEPBS_SlotActionsReplaceAndClear(t *testing.T) {
+	store := payload_bidder.NewSlotActionsStore()
+	h := newSlotActionsTestHandler(t, 10, store)
+
+	// Configure two future slots.
+	code, resp := postEPBS(t, h,
+		`{"slot_actions":{"15":{"reveal":"withhold"},"20":{"reveal":"withhold"}}}`)
+	require.Equal(t, http.StatusOK, code)
+	assert.Equal(t, "updated", resp.Status)
+	require.Len(t, resp.SlotActions, 2)
+	assert.Equal(t, payload_bidder.RevealActionWithhold, resp.SlotActions["15"].Reveal)
+	assert.Equal(t, payload_bidder.RevealActionWithhold, resp.SlotActions["20"].Reveal)
+
+	// Supplying slot_actions replaces the complete pending future set.
+	code, resp = postEPBS(t, h, `{"slot_actions":{"25":{"reveal":"withhold"}}}`)
+	require.Equal(t, http.StatusOK, code)
+	require.Len(t, resp.SlotActions, 1)
+	assert.Contains(t, resp.SlotActions, "25")
+
+	// An empty object clears it.
+	code, resp = postEPBS(t, h, `{"slot_actions":{}}`)
+	require.Equal(t, http.StatusOK, code)
+	assert.Empty(t, resp.SlotActions)
+	assert.Empty(t, store.Snapshot())
+}
+
+func TestUpdateEPBS_SlotActionsImmutableOnceStarted(t *testing.T) {
+	store := payload_bidder.NewSlotActionsStore()
+	h := newSlotActionsTestHandler(t, 10, store)
+
+	code, _ := postEPBS(t, h, `{"slot_actions":{"15":{"reveal":"withhold"}}}`)
+	require.Equal(t, http.StatusOK, code)
+
+	// Slot 15 has started: reconfiguring it is rejected...
+	late := newSlotActionsTestHandler(t, 15, store)
+	code, resp := postEPBS(t, late, `{"slot_actions":{"15":{"reveal":"withhold"}}}`)
+	require.Equal(t, http.StatusBadRequest, code)
+	assert.Equal(t, "slot_actions: slot 15 is not in the future (current slot 15)", resp.Error)
+
+	// ...and clearing leaves the in-flight action in place.
+	code, resp = postEPBS(t, late, `{"slot_actions":{}}`)
+	require.Equal(t, http.StatusOK, code)
+	require.Len(t, resp.SlotActions, 1)
+	assert.Contains(t, resp.SlotActions, "15")
+}
+
+func TestUpdateEPBS_SlotActionsRejectsBoundaryCrossing(t *testing.T) {
+	store := payload_bidder.NewSlotActionsStore()
+	h := newSlotActionsTestHandler(t, 10, store)
+
+	// The first sample sees slot 10, but the commit-point sample sees that the
+	// target slot has started. It must not be inserted using the stale sample.
+	started := phase0.Slot(15)
+	h.chainSvc.(*stubChainService).nextSlot = &started
+
+	code, resp := postEPBS(t, h, `{"slot_actions":{"15":{"reveal":"withhold"}}}`)
+	require.Equal(t, http.StatusBadRequest, code)
+	assert.Equal(t, "slot_actions: slot 15 is not in the future (current slot 15)", resp.Error)
+	assert.Empty(t, store.Snapshot())
+}
+
+func TestUpdateEPBS_SlotActionsValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		body    string
+		wantErr string
+	}{
+		{
+			name:    "malformed slot key",
+			body:    `{"slot_actions":{"abc":{"reveal":"withhold"}}}`,
+			wantErr: `slot_actions: invalid slot key "abc": must be a decimal slot number`,
+		},
+		{
+			name:    "negative slot key",
+			body:    `{"slot_actions":{"-1":{"reveal":"withhold"}}}`,
+			wantErr: `slot_actions: invalid slot key "-1": must be a decimal slot number`,
+		},
+		{
+			name:    "fractional slot key",
+			body:    `{"slot_actions":{"1.5":{"reveal":"withhold"}}}`,
+			wantErr: `slot_actions: invalid slot key "1.5": must be a decimal slot number`,
+		},
+		{
+			name:    "empty slot key",
+			body:    `{"slot_actions":{"":{"reveal":"withhold"}}}`,
+			wantErr: `slot_actions: invalid slot key "": must be a decimal slot number`,
+		},
+		{
+			name:    "empty action",
+			body:    `{"slot_actions":{"15":{}}}`,
+			wantErr: `slot_actions: no action specified for slot 15`,
+		},
+		{
+			name:    "unknown action",
+			body:    `{"slot_actions":{"15":{"bid":"mutate"}}}`,
+			wantErr: `slot_actions: unknown action "bid" for slot 15 (supported: "reveal")`,
+		},
+		{
+			name:    "unknown reveal action",
+			body:    `{"slot_actions":{"15":{"reveal":"delay"}}}`,
+			wantErr: `slot_actions: unknown reveal action "delay" for slot 15 (supported: "withhold")`,
+		},
+		{
+			name:    "current slot",
+			body:    `{"slot_actions":{"10":{"reveal":"withhold"}}}`,
+			wantErr: `slot_actions: slot 10 is not in the future (current slot 10)`,
+		},
+		{
+			name:    "past slot",
+			body:    `{"slot_actions":{"5":{"reveal":"withhold"}}}`,
+			wantErr: `slot_actions: slot 5 is not in the future (current slot 10)`,
+		},
+		{
+			name:    "one bad slot rejects the whole request",
+			body:    `{"slot_actions":{"15":{"reveal":"withhold"},"5":{"reveal":"withhold"}}}`,
+			wantErr: `slot_actions: slot 5 is not in the future (current slot 10)`,
+		},
+		{
+			name:    "non-object action",
+			body:    `{"slot_actions":{"15":"withhold"}}`,
+			wantErr: `invalid request body`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := payload_bidder.NewSlotActionsStore()
+			h := newSlotActionsTestHandler(t, 10, store)
+
+			code, resp := postEPBS(t, h, tt.body)
+			assert.Equal(t, http.StatusBadRequest, code)
+			assert.Equal(t, tt.wantErr, resp.Error)
+			assert.Empty(t, store.Snapshot(), "a rejected request must not touch the store")
+		})
+	}
+}
+
+func TestUpdateEPBS_SlotActionsAbsentLeavesStore(t *testing.T) {
+	store := payload_bidder.NewSlotActionsStore()
+	h := newSlotActionsTestHandler(t, 10, store)
+
+	code, _ := postEPBS(t, h, `{"slot_actions":{"15":{"reveal":"withhold"}}}`)
+	require.Equal(t, http.StatusOK, code)
+
+	// No slot_actions field → existing actions stay; the response still
+	// echoes the effective stored set.
+	code, resp := postEPBS(t, h, `{}`)
+	require.Equal(t, http.StatusOK, code)
+	assert.Equal(t, "updated", resp.Status)
+	require.Len(t, resp.SlotActions, 1)
+	assert.Contains(t, resp.SlotActions, "15")
+	require.Len(t, store.Snapshot(), 1)
+}
+
+func TestUpdateEPBS_SlotActionsNotSupported(t *testing.T) {
+	// No store wired (Gloas not scheduled) → deterministic rejection.
+	h := newSlotActionsTestHandler(t, 10, nil)
+
+	code, resp := postEPBS(t, h, `{"slot_actions":{"15":{"reveal":"withhold"}}}`)
+	assert.Equal(t, http.StatusBadRequest, code)
+	assert.Equal(t, "slot_actions: not supported: Gloas/ePBS is not scheduled on this network", resp.Error)
+}
+
+func TestEventStreamManager_BroadcastWithheld(t *testing.T) {
+	mgr := NewEventStreamManager(nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	client := make(chan *StreamEvent, 1)
+	mgr.AddClient(client)
+
+	defer mgr.RemoveClient(client)
+	defer mgr.Stop()
+
+	before := time.Now().UnixMilli()
+	mgr.BroadcastWithheld(&payload_bidder.RevealResult{
+		Slot:          384,
+		Withheld:      true,
+		Action:        payload_bidder.RevealActionWithhold,
+		BuilderIndex:  42,
+		BuilderPubkey: "0xabc",
+	})
+	after := time.Now().UnixMilli()
+
+	select {
+	case event := <-client:
+		assert.Equal(t, EventTypeIntentionallyWithheld, event.Type)
+		assert.GreaterOrEqual(t, event.Timestamp, before)
+		assert.LessOrEqual(t, event.Timestamp, after)
+
+		data, ok := event.Data.(WithheldStreamEvent)
+		require.True(t, ok)
+		assert.Equal(t, uint64(384), data.Slot)
+		assert.Equal(t, uint64(42), data.BuilderIndex)
+		assert.Equal(t, "0xabc", data.BuilderPubkey)
+		assert.Equal(t, payload_bidder.RevealActionWithhold, data.Action)
+		assert.Equal(t, "intentionally_withheld", data.Status)
+		assert.Equal(t, event.Timestamp, data.Timestamp)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for intentionally_withheld event")
+	}
+}
+
+func TestConfigWithSlotActions(t *testing.T) {
+	cfg := &config.Config{BuilderPrivkey: "secret"}
+	store := payload_bidder.NewSlotActionsStore()
+	store.ReplaceFuture(map[phase0.Slot]*payload_bidder.SlotAction{
+		384: {Reveal: payload_bidder.RevealActionWithhold},
+	}, 10)
+
+	out := configWithSlotActions(cfg, store)
+	assert.Equal(t, "***", out["builder_privkey"])
+
+	epbs, ok := out["epbs"].(map[string]any)
+	require.True(t, ok)
+	actions, ok := epbs["slot_actions"].(map[string]*payload_bidder.SlotAction)
+	require.True(t, ok)
+	require.Contains(t, actions, "384")
+	assert.Equal(t, payload_bidder.RevealActionWithhold, actions["384"].Reveal)
+}

--- a/pkg/webui/handlers/docs/docs.go
+++ b/pkg/webui/handlers/docs/docs.go
@@ -297,7 +297,7 @@ const docTemplate = `{
         },
         "/api/config/epbs": {
             "post": {
-                "description": "Updates the EPBS (enshrined PBS) configuration including timing and bid\nparameters. Requires authentication.",
+                "description": "Updates the EPBS (enshrined PBS) configuration including timing, bid\nparameters, and per-slot reveal actions (slot_actions replaces the pending\nfuture set; only future slots and the \"withhold\" reveal action are\naccepted). Requires authentication.",
                 "consumes": [
                     "application/json"
                 ],
@@ -329,12 +329,10 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                        "description": "Success",
+                        "description": "Success (includes the effective stored slot_actions)",
                         "schema": {
                             "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "additionalProperties": true
                         }
                     },
                     "400": {
@@ -1159,6 +1157,16 @@ const docTemplate = `{
                 },
                 "reveal_time": {
                     "type": "integer"
+                },
+                "slot_actions": {
+                    "description": "SlotActions, when present, replaces the complete set of pending FUTURE\nper-slot actions (an empty object clears it); actions whose slot has\nstarted are immutable. Keys are decimal slot numbers strictly in the\nfuture; the only supported action is {\"reveal\": \"withhold\"}.",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        }
+                    }
                 }
             }
         },

--- a/pkg/webui/handlers/docs/swagger.json
+++ b/pkg/webui/handlers/docs/swagger.json
@@ -286,7 +286,7 @@
         },
         "/api/config/epbs": {
             "post": {
-                "description": "Updates the EPBS (enshrined PBS) configuration including timing and bid\nparameters. Requires authentication.",
+                "description": "Updates the EPBS (enshrined PBS) configuration including timing, bid\nparameters, and per-slot reveal actions (slot_actions replaces the pending\nfuture set; only future slots and the \"withhold\" reveal action are\naccepted). Requires authentication.",
                 "consumes": [
                     "application/json"
                 ],
@@ -318,12 +318,10 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Success",
+                        "description": "Success (includes the effective stored slot_actions)",
                         "schema": {
                             "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "additionalProperties": true
                         }
                     },
                     "400": {
@@ -1148,6 +1146,16 @@
                 },
                 "reveal_time": {
                     "type": "integer"
+                },
+                "slot_actions": {
+                    "description": "SlotActions, when present, replaces the complete set of pending FUTURE\nper-slot actions (an empty object clears it); actions whose slot has\nstarted are immutable. Keys are decimal slot numbers strictly in the\nfuture; the only supported action is {\"reveal\": \"withhold\"}.",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        }
+                    }
                 }
             }
         },

--- a/pkg/webui/handlers/docs/swagger.yaml
+++ b/pkg/webui/handlers/docs/swagger.yaml
@@ -248,6 +248,17 @@ definitions:
         type: integer
       reveal_time:
         type: integer
+      slot_actions:
+        additionalProperties:
+          additionalProperties:
+            type: string
+          type: object
+        description: |-
+          SlotActions, when present, replaces the complete set of pending FUTURE
+          per-slot actions (an empty object clears it); actions whose slot has
+          started are immutable. Keys are decimal slot numbers strictly in the
+          future; the only supported action is {"reveal": "withhold"}.
+        type: object
     type: object
   api.UpdateScheduleRequest:
     properties:
@@ -523,8 +534,10 @@ paths:
       consumes:
       - application/json
       description: |-
-        Updates the EPBS (enshrined PBS) configuration including timing and bid
-        parameters. Requires authentication.
+        Updates the EPBS (enshrined PBS) configuration including timing, bid
+        parameters, and per-slot reveal actions (slot_actions replaces the pending
+        future set; only future slots and the "withhold" reveal action are
+        accepted). Requires authentication.
       operationId: updateEPBS
       parameters:
       - description: Bearer token
@@ -542,10 +555,9 @@ paths:
       - application/json
       responses:
         "200":
-          description: Success
+          description: Success (includes the effective stored slot_actions)
           schema:
-            additionalProperties:
-              type: string
+            additionalProperties: true
             type: object
         "400":
           description: Bad Request

--- a/pkg/webui/src/components/ConfigPanel.tsx
+++ b/pkg/webui/src/components/ConfigPanel.tsx
@@ -1,19 +1,26 @@
 import React, { useState, useEffect } from 'react';
 import { useAuthContext } from '../context/AuthContext';
-import type { Config, EPBSConfig, ServiceStatus } from '../types';
+import type { Config, EPBSConfig, ServiceStatus, SlotAction } from '../types';
 
 interface ConfigPanelProps {
   config: Config | null;
   serviceStatus: ServiceStatus | null;
+  currentSlot: number;
 }
 
 type EPBSFormState = EPBSConfig;
 
-export const ConfigPanel: React.FC<ConfigPanelProps> = ({ config, serviceStatus }) => {
+export const ConfigPanel: React.FC<ConfigPanelProps> = ({ config, serviceStatus, currentSlot }) => {
   const { isLoggedIn, getAuthHeader } = useAuthContext();
   const [collapsed, setCollapsed] = useState(true);
   const [editingTiming, setEditingTiming] = useState(false);
+  const [editingSlotActions, setEditingSlotActions] = useState(false);
   const [toggling, setToggling] = useState(false);
+  const [savingSlotActions, setSavingSlotActions] = useState(false);
+  const [slotActionSlots, setSlotActionSlots] = useState<number[]>([]);
+  const [newSlot, setNewSlot] = useState('');
+  const [slotActionError, setSlotActionError] = useState('');
+  const [displayedSlotActions, setDisplayedSlotActions] = useState<Record<string, SlotAction>>({});
 
   const [timingForm, setTimingForm] = useState<EPBSFormState>({
     build_start_time: 0,
@@ -32,6 +39,22 @@ export const ConfigPanel: React.FC<ConfigPanelProps> = ({ config, serviceStatus 
       setTimingForm({ ...config.epbs });
     }
   }, [config, editingTiming]);
+
+  useEffect(() => {
+    setDisplayedSlotActions(config?.epbs?.slot_actions ?? {});
+  }, [config]);
+
+  // Only future entries are editable. If a configured slot starts while the
+  // form is open, the backend keeps it immutable and the next save omits it.
+  useEffect(() => {
+    if (!editingSlotActions) {
+      const futureSlots = Object.keys(displayedSlotActions)
+        .map(Number)
+        .filter((slot) => Number.isSafeInteger(slot) && slot > currentSlot)
+        .sort((a, b) => a - b);
+      setSlotActionSlots(futureSlots);
+    }
+  }, [displayedSlotActions, currentSlot, editingSlotActions]);
 
   const handleTimingSave = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -67,6 +90,11 @@ export const ConfigPanel: React.FC<ConfigPanelProps> = ({ config, serviceStatus 
 
   const canEdit = isLoggedIn;
   const epbs = config?.epbs;
+  const configuredSlots = Object.keys(displayedSlotActions)
+    .map(Number)
+    .filter(Number.isSafeInteger)
+    .sort((a, b) => a - b);
+  const lockedSlots = configuredSlots.filter((slot) => slot <= currentSlot);
   const isActive = serviceStatus?.epbs_enabled ?? false;
   const isAvailable = serviceStatus?.epbs_available ?? false;
   const registrationState = serviceStatus?.epbs_registration_state ?? 'unknown';
@@ -92,6 +120,67 @@ export const ConfigPanel: React.FC<ConfigPanelProps> = ({ config, serviceStatus 
     } finally {
       setToggling(false);
     }
+  };
+
+  const addSlotAction = () => {
+    const slot = Number(newSlot);
+    if (!Number.isSafeInteger(slot) || slot < 0) {
+      setSlotActionError('Slot must be a non-negative whole number.');
+      return;
+    }
+    if (slot <= currentSlot) {
+      setSlotActionError(`Slot must be in the future (current slot ${currentSlot}).`);
+      return;
+    }
+
+    setSlotActionSlots((slots) => [...new Set([...slots, slot])].sort((a, b) => a - b));
+    setNewSlot('');
+    setSlotActionError('');
+  };
+
+  const postSlotActions = async (slots: number[]) => {
+    const headers: HeadersInit = { 'Content-Type': 'application/json' };
+    const authToken = getAuthHeader();
+    if (authToken) {
+      headers['Authorization'] = `Bearer ${authToken}`;
+    }
+
+    const slotActions = Object.fromEntries(
+      slots
+        .filter((slot) => slot > currentSlot)
+        .map((slot) => [String(slot), { reveal: 'withhold' as const }])
+    );
+
+    setSavingSlotActions(true);
+    setSlotActionError('');
+    try {
+      const response = await fetch('/api/config/epbs', {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ slot_actions: slotActions }),
+      });
+      const result = await response.json();
+      if (!response.ok || result.error) {
+        throw new Error(result.error || `request failed with status ${response.status}`);
+      }
+
+      setDisplayedSlotActions(result.slot_actions ?? {});
+      setEditingSlotActions(false);
+      setNewSlot('');
+    } catch (err) {
+      setSlotActionError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSavingSlotActions(false);
+    }
+  };
+
+  const handleSlotActionsSave = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await postSlotActions(slotActionSlots);
+  };
+
+  const handleClearSlotActions = async () => {
+    await postSlotActions([]);
   };
 
   return (
@@ -281,6 +370,134 @@ export const ConfigPanel: React.FC<ConfigPanelProps> = ({ config, serviceStatus 
               <div className="d-flex gap-2">
                 <button type="submit" className="btn btn-sm btn-primary">Save</button>
                 <button type="button" className="btn btn-sm btn-secondary" onClick={() => setEditingTiming(false)}>
+                  Cancel
+                </button>
+              </div>
+            </form>
+          )}
+
+          <hr className="my-3" />
+
+          {/* Exact-slot reveal fault actions */}
+          <div className="d-flex justify-content-between align-items-center mb-2">
+            <div className="section-header">Exact-slot Reveal Actions</div>
+            {canEdit && isAvailable && !editingSlotActions && (
+              <button
+                className="btn btn-sm btn-outline-primary"
+                onClick={() => {
+                  setSlotActionError('');
+                  setEditingSlotActions(true);
+                }}
+                title="Configure exact slots that should withhold their payload reveal"
+              >
+                <i className="fas fa-pencil-alt"></i>
+              </button>
+            )}
+          </div>
+
+          {!editingSlotActions ? (
+            <div>
+              {configuredSlots.length === 0 ? (
+                <div className="text-muted small">No reveal withholding actions configured.</div>
+              ) : (
+                <div className="d-flex flex-column gap-2">
+                  {configuredSlots.map((slot) => (
+                    <div key={slot} className="config-item d-flex justify-content-between align-items-center">
+                      <div>
+                        <div className="config-item-label">Slot {slot}</div>
+                        <div className="config-item-value">Withhold payload reveal</div>
+                      </div>
+                      <span className={`badge ${slot <= currentSlot ? 'bg-secondary' : 'bg-warning text-dark'}`}>
+                        {slot <= currentSlot ? 'Locked' : 'Pending'}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              )}
+              <div className="form-text mt-2">
+                Buildoor still builds and bids normally. If it wins a configured slot, it retains the payload and does not publish the envelope.
+              </div>
+            </div>
+          ) : (
+            <form onSubmit={handleSlotActionsSave}>
+              {lockedSlots.length > 0 && (
+                <div className="alert alert-secondary small py-1 px-2">
+                  Slot{lockedSlots.length > 1 ? 's' : ''} {lockedSlots.join(', ')} already started and will remain locked.
+                </div>
+              )}
+
+              <div className="input-group input-group-sm mb-2">
+                <span className="input-group-text">Slot</span>
+                <input
+                  type="number"
+                  className="form-control"
+                  value={newSlot}
+                  min={Math.max(0, currentSlot + 1)}
+                  max={Number.MAX_SAFE_INTEGER}
+                  step={1}
+                  placeholder={`>${currentSlot}`}
+                  onChange={(e) => setNewSlot(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                      e.preventDefault();
+                      addSlotAction();
+                    }
+                  }}
+                />
+                <button type="button" className="btn btn-outline-primary" onClick={addSlotAction} disabled={!newSlot}>
+                  <i className="fas fa-plus me-1"></i>Add
+                </button>
+              </div>
+
+              {slotActionSlots.length === 0 ? (
+                <div className="text-muted small mb-2">No pending future actions. Saving will clear the pending set.</div>
+              ) : (
+                <div className="list-group mb-2">
+                  {slotActionSlots.map((slot) => (
+                    <div key={slot} className="list-group-item py-1 px-2 d-flex justify-content-between align-items-center">
+                      <span><strong>Slot {slot}</strong> — withhold reveal</span>
+                      <button
+                        type="button"
+                        className="btn btn-sm btn-outline-danger border-0"
+                        onClick={() => setSlotActionSlots((slots) => slots.filter((item) => item !== slot))}
+                        title={`Remove slot ${slot}`}
+                      >
+                        <i className="fas fa-times"></i>
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              {slotActionError && (
+                <div className="alert alert-danger small py-1 px-2 mb-2">{slotActionError}</div>
+              )}
+
+              <div className="form-text mb-2">
+                Saving replaces the complete pending future set. Actions become immutable when their slot starts.
+              </div>
+              <div className="d-flex flex-wrap gap-2">
+                <button type="submit" className="btn btn-sm btn-primary" disabled={savingSlotActions}>
+                  {savingSlotActions ? 'Saving…' : 'Save actions'}
+                </button>
+                <button
+                  type="button"
+                  className="btn btn-sm btn-outline-danger"
+                  onClick={handleClearSlotActions}
+                  disabled={savingSlotActions || slotActionSlots.length === 0}
+                >
+                  Clear pending
+                </button>
+                <button
+                  type="button"
+                  className="btn btn-sm btn-secondary"
+                  onClick={() => {
+                    setEditingSlotActions(false);
+                    setSlotActionError('');
+                    setNewSlot('');
+                  }}
+                  disabled={savingSlotActions}
+                >
                   Cancel
                 </button>
               </div>

--- a/pkg/webui/src/components/Legend.tsx
+++ b/pkg/webui/src/components/Legend.tsx
@@ -18,6 +18,7 @@ export const Legend: React.FC = () => {
         <span><span className="legend-dot bg-bid-failed"></span> Bid Failed</span>
         <span><span className="legend-dot bg-reveal-sent"></span> Reveal</span>
         <span><span className="legend-dot bg-reveal-failed"></span> Reveal Failed</span>
+        <span><span className="legend-dot bg-reveal-withheld"></span> Reveal Withheld</span>
         <span className="legend-section ms-2">Builder API:</span>
         <span><span className="legend-dot bg-builder-api-delivered"></span> Call delivered</span>
         <span><span className="legend-dot bg-builder-api-pending"></span> Call pending</span>

--- a/pkg/webui/src/components/SlotGraph.tsx
+++ b/pkg/webui/src/components/SlotGraph.tsx
@@ -560,6 +560,31 @@ export const SlotGraph: React.FC<SlotGraphProps> = ({
                 `reveal-${idx}`
               );
             })}
+
+            {/* Configured fault receipt — distinct from a failed publication,
+                because no envelope publication was attempted. */}
+            {genesisTime > 0 && state.revealWithheldAt && renderEventDot(
+              'reveal-withheld',
+              state.revealWithheldAt - slotStartTime,
+              {
+                title: 'Reveal Intentionally Withheld',
+                items: [
+                  { label: 'Time', value: `${state.revealWithheldAt - slotStartTime}ms` },
+                  { label: 'Action', value: 'withhold' },
+                  { label: 'Status', value: 'intentionally_withheld' },
+                  ...(state.revealWithheldBuilderIndex !== undefined ? [{
+                    label: 'Builder Index',
+                    value: String(state.revealWithheldBuilderIndex)
+                  }] : []),
+                  ...(state.revealWithheldBuilderPubkey ? [{
+                    label: 'Builder Pubkey',
+                    value: truncateHash(state.revealWithheldBuilderPubkey),
+                    copyValue: state.revealWithheldBuilderPubkey
+                  }] : [])
+                ]
+              },
+              'reveal-withheld'
+            )}
           </div>
         )}
 
@@ -651,8 +676,8 @@ export const SlotGraph: React.FC<SlotGraphProps> = ({
                 items: [
                   { label: 'Received', value: `${state.submitBlockReceivedAt - slotStartTime}ms` },
                   state.submitBlockDeliveredAt
-                    ? { label: 'Revealed', value: `${state.submitBlockDeliveredAt - slotStartTime}ms` }
-                    : { label: 'Status', value: 'not revealed' },
+                    ? { label: 'Block Accepted', value: `${state.submitBlockDeliveredAt - slotStartTime}ms` }
+                    : { label: 'Status', value: 'block not accepted' },
                   ...(state.submitBlockBlockHash ? [{
                     label: 'Block Hash',
                     value: truncateHash(state.submitBlockBlockHash),

--- a/pkg/webui/src/hooks/useEventStream.ts
+++ b/pkg/webui/src/hooks/useEventStream.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import type { Config, ChainInfo, Stats, SlotState, LogEvent, OurBid, ExternalBid, BuilderInfo, HeadVoteDataPoint, ServiceStatus, RevealAttempt } from '../types';
+import type { Config, ChainInfo, Stats, SlotState, LogEvent, OurBid, ExternalBid, BuilderInfo, HeadVoteDataPoint, ServiceStatus, RevealAttempt, IntentionallyWithheldEvent } from '../types';
 
 interface UseEventStreamResult {
   connected: boolean;
@@ -316,6 +316,22 @@ export function useEventStream(): UseEventStreamResult {
           break;
         }
 
+        case 'intentionally_withheld': {
+          const data = event.data as IntentionallyWithheldEvent;
+          addEvent(
+            'reveal_withheld',
+            `Reveal intentionally withheld for slot ${data.slot} by builder ${data.builder_index}`,
+            data.timestamp || event.timestamp
+          );
+          updateSlotState(data.slot, {
+            revealed: false,
+            revealWithheldAt: data.timestamp || event.timestamp,
+            revealWithheldBuilderIndex: data.builder_index,
+            revealWithheldBuilderPubkey: data.builder_pubkey
+          });
+          break;
+        }
+
         case 'bid_event': {
           const data = event.data as { slot: number; builder_index: number; value: number; block_hash: string; is_ours: boolean; received_at: number };
           if (data.is_ours) {
@@ -435,7 +451,7 @@ export function useEventStream(): UseEventStreamResult {
 
         case 'builder_api_submit_block_delivered': {
           const data = event.data as { slot: number; block_hash: string; delivered_at: number };
-          addEvent('builder_api', `Envelope published for slot ${data.slot}`, event.timestamp);
+          addEvent('builder_api', `Signed beacon block accepted for slot ${data.slot}`, event.timestamp);
           updateSlotState(data.slot, { submitBlockDeliveredAt: data.delivered_at });
           break;
         }

--- a/pkg/webui/src/pages/DashboardPage.tsx
+++ b/pkg/webui/src/pages/DashboardPage.tsx
@@ -117,7 +117,7 @@ const DashboardPage: React.FC = () => {
           <BuilderConfigPanel config={config} />
 
           {/* ePBS Bidder */}
-          <ConfigPanel config={config} serviceStatus={serviceStatus} />
+          <ConfigPanel config={config} serviceStatus={serviceStatus} currentSlot={currentSlot} />
 
           {/* Builder API */}
           <BuilderAPIConfigPanel status={builderAPIStatus} serviceStatus={serviceStatus} loading={builderAPIStatusLoading} />

--- a/pkg/webui/src/styles.css
+++ b/pkg/webui/src/styles.css
@@ -266,6 +266,11 @@
   border: 2px solid #bd2130;
 }
 
+.reveal-withheld {
+  background: #ffc107;
+  border: 2px solid #d39e00;
+}
+
 .build-failed {
   background: #dc3545;
   border: 2px solid #bd2130;
@@ -486,6 +491,7 @@
 .bg-bid-failed { background: #dc3545; }
 .bg-reveal-sent { background: #6f42c1; }
 .bg-reveal-failed { background: #dc3545; }
+.bg-reveal-withheld { background: #ffc107; }
 .bg-head-votes { background: #00bcd4; }
 .bg-builder-api-delivered { background: #28a745; }
 .bg-builder-api-pending { background: #ffc107; }

--- a/pkg/webui/src/types.ts
+++ b/pkg/webui/src/types.ts
@@ -47,6 +47,11 @@ export interface EPBSConfig {
   bid_interval: number;
   bid_subsidy: number;
   payload_build_delay?: number;
+  slot_actions?: Record<string, SlotAction>;
+}
+
+export interface SlotAction {
+  reveal: 'withhold';
 }
 
 export interface ServiceStatus {
@@ -148,6 +153,15 @@ export interface RevealEvent {
   timestamp: number;
 }
 
+export interface IntentionallyWithheldEvent {
+  slot: number;
+  builder_index: number;
+  builder_pubkey: string;
+  action: 'withhold';
+  status: 'intentionally_withheld';
+  timestamp: number;
+}
+
 // A single payload reveal attempt (the reveal may be retried on failure).
 export interface RevealAttempt {
   time: number;
@@ -191,6 +205,9 @@ export interface SlotState {
   revealFailed?: boolean;
   revealSentAt?: number;
   revealAttempts?: RevealAttempt[];
+  revealWithheldAt?: number;
+  revealWithheldBuilderIndex?: number;
+  revealWithheldBuilderPubkey?: string;
   headVotes?: HeadVoteDataPoint[];
   getHeaderReceivedAt?: number;
   getHeaderDeliveredAt?: number;

--- a/pkg/webui/src/utils.ts
+++ b/pkg/webui/src/utils.ts
@@ -64,6 +64,7 @@ export function getEventTypeClass(type: string): string {
     'bid_event': 'event-color-external-bid',               // external-bid dot
     'payload_available': 'event-color-payload-available',  // payload-available dot
     'reveal': 'event-color-reveal',                        // reveal-sent dot
+    'reveal_withheld': 'event-warning',                    // intentional test fault
     'bid_won': 'event-color-bid-won',                      // bid-won crown
     'builder_api': 'event-color-builder-api'               // builder-api dot
 
@@ -90,6 +91,7 @@ const EVENT_TYPE_CATEGORY: Record<string, string> = {
   bid_event: 'external_bid',
   payload_available: 'available',
   reveal: 'reveal',
+  reveal_withheld: 'reveal',
   bid_won: 'bid_won',
   builder_api: 'builder_api',
   payload_build_failed: 'error',

--- a/pkg/webui/webui.go
+++ b/pkg/webui/webui.go
@@ -41,7 +41,7 @@ var (
 	staticEmbedFS embed.FS
 )
 
-func StartHttpServer(frontendConfig *types.FrontendConfig, settingsSvc *config.Service, stateDB *db.Database, builderSvc *payload_builder.Service, epbsSvc *p2p_bidder.Service, lifecycleMgr *lifecycle.Manager, chainSvc chain.Service, validatorStore *memstore.Store[phase0.BLSPubKey, *apiv1.SignedValidatorRegistration], builderAPISvc *builderapi.Server, propPrefSvc *payload_bidder.ProposerPreferencesService, valRanges *validatorranges.Resolver, revealSvc *payload_bidder.RevealService, inclusionTracker *payload_bidder.InclusionTracker, payments *payload_bidder.PaymentTracker) *api.APIHandler {
+func StartHttpServer(frontendConfig *types.FrontendConfig, settingsSvc *config.Service, stateDB *db.Database, builderSvc *payload_builder.Service, epbsSvc *p2p_bidder.Service, lifecycleMgr *lifecycle.Manager, chainSvc chain.Service, validatorStore *memstore.Store[phase0.BLSPubKey, *apiv1.SignedValidatorRegistration], builderAPISvc *builderapi.Server, propPrefSvc *payload_bidder.ProposerPreferencesService, valRanges *validatorranges.Resolver, revealSvc *payload_bidder.RevealService, inclusionTracker *payload_bidder.InclusionTracker, payments *payload_bidder.PaymentTracker, slotActions *payload_bidder.SlotActionsStore) *api.APIHandler {
 	authHandler, err := auth.NewAuthHandler(context.Background(), frontendConfig.AuthProviderURL)
 	if err != nil {
 		logrus.WithError(err).Fatal("failed to initialize auth handler")
@@ -59,7 +59,7 @@ func StartHttpServer(frontendConfig *types.FrontendConfig, settingsSvc *config.S
 	}
 
 	// API routes
-	apiHandler := api.NewAPIHandler(authHandler, settingsSvc, stateDB, builderSvc, epbsSvc, lifecycleMgr, chainSvc, validatorStore, builderAPISvc, propPrefSvc, valRanges, revealSvc, inclusionTracker, payments)
+	apiHandler := api.NewAPIHandler(authHandler, settingsSvc, stateDB, builderSvc, epbsSvc, lifecycleMgr, chainSvc, validatorStore, builderAPISvc, propPrefSvc, valRanges, revealSvc, inclusionTracker, payments, slotActions)
 	apiRouter := router.PathPrefix("/api").Subrouter()
 	apiRouter.HandleFunc("/version", apiHandler.GetVersion).Methods("GET")
 	apiRouter.HandleFunc("/status", apiHandler.GetStatus).Methods(http.MethodGet)


### PR DESCRIPTION
## Summary

- add persisted exact-slot `reveal: withhold` actions to the ePBS runtime API and Web UI
- suppress payload-envelope publication for configured winning slots while retaining payload artifacts and emitting an `intentionally_withheld` event receipt
- enforce replacement, clearing, validation, and slot-boundary locking semantics for scheduled actions
- align Gloas bid and envelope signing roots with the Glamsterdam bounded-list schema and harden startup/reveal edge cases
- update API documentation, generated UI assets, and unit coverage

## Testing

- `go mod verify`
- `go vet ./...`
- `staticcheck ./...`
- `go test ./...`
- `go test -race -vet=off ./...`
- `npm run build` in `pkg/webui`