### PR TITLE
fix(epbs): add opt-in devnet-6 SSZ compatibility

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -58,6 +58,7 @@ func init() {
 	rootCmd.PersistentFlags().String("overview-url", "", "Optional URL of the multi-instance overview UI. When set, the dashboard renders an Overview entry as the first top-nav item so navigation stays consistent across instances.")
 	rootCmd.PersistentFlags().Bool("lifecycle", false, "Enable builder lifecycle management")
 	rootCmd.PersistentFlags().Bool("epbs-enabled", false, "Enable ePBS bidding/revealing at startup")
+	rootCmd.PersistentFlags().Bool("epbs-legacy-gloas-ssz", false, "Use pre-EIP-7688 bounded SSZ roots for Glamsterdam devnet-6 compatibility")
 	rootCmd.PersistentFlags().Bool("builder-api-enabled", defaults.BuilderAPIEnabled, "Enable traditional Builder API at startup (served on --api-port)")
 	rootCmd.PersistentFlags().Uint64("builder-api-subsidy", defaults.BuilderAPI.BlockValueSubsidyGwei, "Gwei added to the bid value in both Fulu (getHeader) and Gloas (ExecutionPayment) Builder API bids")
 	rootCmd.PersistentFlags().String("builder-api-url", defaults.BuilderAPI.BuilderURL, "Publicly reachable URL of this builder (e.g. https://builder.example.com); used to validate builder_url in SignedRequestAuthV1")
@@ -178,6 +179,7 @@ func initConfig() error {
 			StartSlot: v.GetUint64("schedule-start-slot"),
 		},
 		EPBS: config.EPBSConfig{
+			LegacyGloasSSZ: v.GetBool("epbs-legacy-gloas-ssz"),
 			BuildStartTime: v.GetInt64("build-start-time"),
 			BidStartTime:   v.GetInt64("epbs-bid-start"),
 			BidEndTime:     v.GetInt64("epbs-bid-end"),

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -298,7 +298,10 @@ and begins building blocks according to configuration.`,
 		if epbsAvailable {
 			paymentTracker = payload_bidder.NewPaymentTracker(chainSvc, logger)
 
-			revealSvc = payload_bidder.NewRevealService(cfg, payload_bidder.NewSigner(blsSigner), clClient, chainSvc, builderSvc, paymentTracker, logger)
+			revealSvc = payload_bidder.NewRevealService(cfg, payload_bidder.NewSigner(
+				blsSigner,
+				payload_bidder.WithLegacyGloasSSZ(cfg.EPBS.LegacyGloasSSZ),
+			), clClient, chainSvc, builderSvc, paymentTracker, logger)
 			if err := revealSvc.Start(ctx); err != nil {
 				return fmt.Errorf("failed to start reveal service: %w", err)
 			}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -168,8 +168,22 @@ and begins building blocks according to configuration.`,
 		// Configure the global dynssz instance with this network's spec so the
 		// go-eth2-client SSZ codecs (block.Root(), envelope HashTreeRoot, ...)
 		// compute correct hash-tree-roots on non-mainnet presets (e.g. minimal).
-		if err := clClient.InitGlobalSSZSpecs(ctx); err != nil {
-			return fmt.Errorf("failed to init global SSZ specs: %w", err)
+		for {
+			err = clClient.InitGlobalSSZSpecs(ctx)
+			if err == nil {
+				break
+			}
+
+			// A beacon node can serve /config/spec and /genesis just before it
+			// reports an active client to the follow-up SSZ initialization call.
+			// Treat that readiness window like the preceding startup probes.
+			logger.WithError(err).Warn("Beacon node SSZ specs not ready, retrying in 5s...")
+
+			select {
+			case <-ctx.Done():
+				return fmt.Errorf("failed to init global SSZ specs: %w", ctx.Err())
+			case <-time.After(5 * time.Second):
+			}
 		}
 
 		// Apply slot-relative timing defaults now that we know the slot duration

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -99,6 +99,11 @@ type BuilderAPIConfig struct {
 
 // EPBSConfig defines time-scheduled bidding parameters for ePBS.
 type EPBSConfig struct {
+	// LegacyGloasSSZ uses the bounded-list, binary-container SSZ schema from
+	// Glamsterdam devnet-6. It is disabled by default so current networks keep
+	// the EIP-7688 progressive schema introduced for devnet-7.
+	LegacyGloasSSZ bool `yaml:"legacy_gloas_ssz" json:"legacy_gloas_ssz"`
+
 	// BuildStartTime is milliseconds relative to the proposal slot start when we
 	// start building. Negative values mean before the slot starts (e.g. -3000 =
 	// 3 seconds before slot start). Positive values mean after slot start.

--- a/pkg/p2p_bidder/service.go
+++ b/pkg/p2p_bidder/service.go
@@ -116,7 +116,10 @@ func NewService(
 	serviceLog := log.WithField("component", "p2p-bidder")
 
 	// Create the shared payload bidder signer
-	epbsSigner := payload_bidder.NewSigner(blsSigner)
+	epbsSigner := payload_bidder.NewSigner(
+		blsSigner,
+		payload_bidder.WithLegacyGloasSSZ(cfg.LegacyGloasSSZ),
+	)
 
 	s := &Service{
 		cfg:                   cfg,

--- a/pkg/payload_bidder/bid.go
+++ b/pkg/payload_bidder/bid.go
@@ -41,7 +41,7 @@ func BuildSignedBid(
 		execRequests = &eth2all.ExecutionRequests{Version: p.ExecutionPayload.Version}
 	}
 
-	execRequestsRoot, err := hashGloasExecutionRequests(execRequests)
+	execRequestsRoot, err := s.hashExecutionRequests(execRequests)
 	if err != nil {
 		return nil, fmt.Errorf("failed to compute execution requests root: %w", err)
 	}
@@ -80,11 +80,10 @@ func BuildSignedBid(
 	}, nil
 }
 
-// gloasExecutionRequestsSigningView pins the five request collections to the
-// bounded-list schema used by the Glamsterdam Gloas specification. The
-// go-eth2-client v0.1.6 fork-agnostic view uses progressive lists, which is a
-// different SSZ type and therefore commits a different root into the bid.
-type gloasExecutionRequestsSigningView struct {
+// legacyGloasExecutionRequestsSigningView pins the five request collections
+// to the bounded-list schema used by Glamsterdam devnet-6. Current Buildoor
+// defaults to the EIP-7688 progressive schema used by devnet-7 and later.
+type legacyGloasExecutionRequestsSigningView struct {
 	Deposits        []*electra.DepositRequest       `ssz-max:"8192"`
 	Withdrawals     []*electra.WithdrawalRequest    `ssz-max:"16"`
 	Consolidations  []*electra.ConsolidationRequest `ssz-max:"2"`
@@ -92,8 +91,8 @@ type gloasExecutionRequestsSigningView struct {
 	BuilderExits    []*gloas.BuilderExitRequest     `ssz-max:"16"`
 }
 
-func hashGloasExecutionRequests(requests *eth2all.ExecutionRequests) (phase0.Root, error) {
-	view := &gloasExecutionRequestsSigningView{
+func hashLegacyGloasExecutionRequests(requests *eth2all.ExecutionRequests) (phase0.Root, error) {
+	view := &legacyGloasExecutionRequestsSigningView{
 		Deposits:        requests.Deposits,
 		Withdrawals:     requests.Withdrawals,
 		Consolidations:  requests.Consolidations,

--- a/pkg/payload_bidder/bid.go
+++ b/pkg/payload_bidder/bid.go
@@ -6,6 +6,7 @@ import (
 	eth2all "github.com/ethpandaops/go-eth2-client/spec/all"
 	"github.com/ethpandaops/go-eth2-client/spec/bellatrix"
 	"github.com/ethpandaops/go-eth2-client/spec/deneb"
+	"github.com/ethpandaops/go-eth2-client/spec/electra"
 	"github.com/ethpandaops/go-eth2-client/spec/gloas"
 	"github.com/ethpandaops/go-eth2-client/spec/phase0"
 	dynssz "github.com/pk910/dynamic-ssz"
@@ -40,8 +41,7 @@ func BuildSignedBid(
 		execRequests = &eth2all.ExecutionRequests{Version: p.ExecutionPayload.Version}
 	}
 
-	// dynssz so preset-dependent list limits resolve from the global spec.
-	execRequestsRoot, err := dynssz.GetGlobalDynSsz().HashTreeRoot(execRequests)
+	execRequestsRoot, err := hashGloasExecutionRequests(execRequests)
 	if err != nil {
 		return nil, fmt.Errorf("failed to compute execution requests root: %w", err)
 	}
@@ -78,4 +78,33 @@ func BuildSignedBid(
 		Message:   bid,
 		Signature: sig,
 	}, nil
+}
+
+// gloasExecutionRequestsSigningView pins the five request collections to the
+// bounded-list schema used by the Glamsterdam Gloas specification. The
+// go-eth2-client v0.1.6 fork-agnostic view uses progressive lists, which is a
+// different SSZ type and therefore commits a different root into the bid.
+type gloasExecutionRequestsSigningView struct {
+	Deposits        []*electra.DepositRequest       `ssz-max:"8192"`
+	Withdrawals     []*electra.WithdrawalRequest    `ssz-max:"16"`
+	Consolidations  []*electra.ConsolidationRequest `ssz-max:"2"`
+	BuilderDeposits []*gloas.BuilderDepositRequest  `ssz-max:"256"`
+	BuilderExits    []*gloas.BuilderExitRequest     `ssz-max:"16"`
+}
+
+func hashGloasExecutionRequests(requests *eth2all.ExecutionRequests) (phase0.Root, error) {
+	view := &gloasExecutionRequestsSigningView{
+		Deposits:        requests.Deposits,
+		Withdrawals:     requests.Withdrawals,
+		Consolidations:  requests.Consolidations,
+		BuilderDeposits: requests.BuilderDeposits,
+		BuilderExits:    requests.BuilderExits,
+	}
+
+	root, err := dynssz.GetGlobalDynSsz().HashTreeRoot(view)
+	if err != nil {
+		return phase0.Root{}, fmt.Errorf("failed to compute Gloas execution requests root: %w", err)
+	}
+
+	return phase0.Root(root), nil
 }

--- a/pkg/payload_bidder/inclusion_tracker.go
+++ b/pkg/payload_bidder/inclusion_tracker.go
@@ -168,6 +168,14 @@ func (t *InclusionTracker) processHead(event *beacon.HeadEvent) {
 		return
 	}
 
+	// The head event is the authoritative source for the canonical block root.
+	// In particular, go-eth2-client v0.1.6 hashes the nested Gloas bid's blob
+	// commitments as a progressive list, while Glamsterdam uses a bounded list;
+	// recomputing the block root through that schema makes an otherwise valid
+	// envelope reference an unknown block. Keep the decoded block for all other
+	// fields, but preserve the root supplied by the beacon node.
+	blockInfo.Root = event.Block
+
 	t.processBlockInfo(blockInfo)
 }
 

--- a/pkg/payload_bidder/inclusion_tracker.go
+++ b/pkg/payload_bidder/inclusion_tracker.go
@@ -170,10 +170,11 @@ func (t *InclusionTracker) processHead(event *beacon.HeadEvent) {
 
 	// The head event is the authoritative source for the canonical block root.
 	// In particular, go-eth2-client v0.1.6 hashes the nested Gloas bid's blob
-	// commitments as a progressive list, while Glamsterdam uses a bounded list;
-	// recomputing the block root through that schema makes an otherwise valid
-	// envelope reference an unknown block. Keep the decoded block for all other
-	// fields, but preserve the root supplied by the beacon node.
+	// commitments as a progressive list, while the devnet-6 compatibility mode
+	// uses a bounded list. Recomputing the block root through the current library
+	// schema can therefore make an otherwise valid devnet-6 envelope reference
+	// look like an unknown block. Keep the decoded block for all other fields,
+	// but preserve the root supplied by the beacon node.
 	blockInfo.Root = event.Block
 
 	t.processBlockInfo(blockInfo)

--- a/pkg/payload_bidder/reveal.go
+++ b/pkg/payload_bidder/reveal.go
@@ -30,10 +30,15 @@ func BuildSignedEnvelope(
 	forkVersion phase0.Version,
 	genesisValidatorsRoot phase0.Root,
 ) (signed *eth2all.SignedExecutionPayloadEnvelope, blobs, proofs [][]byte, err error) {
+	execRequests := p.ExecutionRequests
+	if execRequests == nil {
+		execRequests = &eth2all.ExecutionRequests{Version: p.ExecutionPayload.Version}
+	}
+
 	envelope := &eth2all.ExecutionPayloadEnvelope{
 		Version:               p.ExecutionPayload.Version,
 		Payload:               p.ExecutionPayload,
-		ExecutionRequests:     p.ExecutionRequests,
+		ExecutionRequests:     execRequests,
 		BuilderIndex:          gloas.BuilderIndex(rc.BuilderIndex),
 		BeaconBlockRoot:       rc.BeaconBlockRoot,
 		ParentBeaconBlockRoot: rc.ParentBeaconBlockRoot,

--- a/pkg/payload_bidder/signer.go
+++ b/pkg/payload_bidder/signer.go
@@ -32,12 +32,29 @@ var DomainBeaconBuilder = phase0.DomainType{0x0B, 0x00, 0x00, 0x00}
 
 // Signer signs execution payload bids and envelopes with the builder's BLS key.
 type Signer struct {
-	blsSigner *signer.BLSSigner
+	blsSigner      *signer.BLSSigner
+	legacyGloasSSZ bool
+}
+
+// SignerOption configures a payload bidder signer.
+type SignerOption func(*Signer)
+
+// WithLegacyGloasSSZ enables the bounded-list, binary-container Gloas schema
+// used by Glamsterdam devnet-6. The default remains EIP-7688 progressive SSZ.
+func WithLegacyGloasSSZ(enabled bool) SignerOption {
+	return func(s *Signer) {
+		s.legacyGloasSSZ = enabled
+	}
 }
 
 // NewSigner creates a new payload bidder signer.
-func NewSigner(blsSigner *signer.BLSSigner) *Signer {
-	return &Signer{blsSigner: blsSigner}
+func NewSigner(blsSigner *signer.BLSSigner, opts ...SignerOption) *Signer {
+	s := &Signer{blsSigner: blsSigner}
+	for _, opt := range opts {
+		opt(s)
+	}
+
+	return s
 }
 
 // SignBid signs an execution payload bid. forkVersion must be the fork version
@@ -47,8 +64,8 @@ func (s *Signer) SignBid(
 	forkVersion phase0.Version,
 	genesisValidatorsRoot phase0.Root,
 ) (phase0.BLSSignature, error) {
-	if bid.Version == version.DataVersionGloas {
-		root, err := hashGloasBid(bid)
+	if s.legacyGloasSSZ && bid.Version == version.DataVersionGloas {
+		root, err := hashLegacyGloasBid(bid)
 		if err != nil {
 			return phase0.BLSSignature{}, err
 		}
@@ -65,8 +82,8 @@ func (s *Signer) SignEnvelope(
 	forkVersion phase0.Version,
 	genesisValidatorsRoot phase0.Root,
 ) (phase0.BLSSignature, error) {
-	if envelope.Version == version.DataVersionGloas {
-		root, err := hashGloasEnvelope(envelope)
+	if s.legacyGloasSSZ && envelope.Version == version.DataVersionGloas {
+		root, err := hashLegacyGloasEnvelope(envelope)
 		if err != nil {
 			return phase0.BLSSignature{}, err
 		}
@@ -107,11 +124,22 @@ func (s *Signer) signRoot(
 	return s.blsSigner.SignWithDomain(root, domain)
 }
 
-// gloasBidSigningView pins the Gloas commitments field to the bounded-list
-// schema used by the Glamsterdam consensus specification. go-eth2-client
-// v0.1.6 models this field as a progressive list, which produces a different
-// signing root even though its JSON and wire fields are otherwise identical.
-type gloasBidSigningView struct {
+func (s *Signer) hashExecutionRequests(requests *eth2all.ExecutionRequests) (phase0.Root, error) {
+	if s.legacyGloasSSZ && requests.Version == version.DataVersionGloas {
+		return hashLegacyGloasExecutionRequests(requests)
+	}
+
+	root, err := dynssz.GetGlobalDynSsz().HashTreeRoot(requests)
+	if err != nil {
+		return phase0.Root{}, fmt.Errorf("failed to compute execution requests root: %w", err)
+	}
+
+	return phase0.Root(root), nil
+}
+
+// legacyGloasBidSigningView pins the Gloas commitments field to the
+// bounded-list, binary-container schema used by Glamsterdam devnet-6.
+type legacyGloasBidSigningView struct {
 	ParentBlockHash       phase0.Hash32              `ssz-size:"32"`
 	ParentBlockRoot       phase0.Root                `ssz-size:"32"`
 	BlockHash             phase0.Hash32              `ssz-size:"32"`
@@ -126,8 +154,8 @@ type gloasBidSigningView struct {
 	ExecutionRequestsRoot phase0.Root           `ssz-size:"32"`
 }
 
-func hashGloasBid(bid *eth2all.ExecutionPayloadBid) (phase0.Root, error) {
-	view := &gloasBidSigningView{
+func hashLegacyGloasBid(bid *eth2all.ExecutionPayloadBid) (phase0.Root, error) {
+	view := &legacyGloasBidSigningView{
 		ParentBlockHash:       bid.ParentBlockHash,
 		ParentBlockRoot:       bid.ParentBlockRoot,
 		BlockHash:             bid.BlockHash,
@@ -150,7 +178,7 @@ func hashGloasBid(bid *eth2all.ExecutionPayloadBid) (phase0.Root, error) {
 	return phase0.Root(root), nil
 }
 
-type gloasPayloadSigningView struct {
+type legacyGloasPayloadSigningView struct {
 	ParentHash      phase0.Hash32              `ssz-size:"32"`
 	FeeRecipient    bellatrix.ExecutionAddress `ssz-size:"20"`
 	StateRoot       phase0.Root                `ssz-size:"32"`
@@ -172,23 +200,23 @@ type gloasPayloadSigningView struct {
 	SlotNumber      uint64
 }
 
-type gloasEnvelopeSigningView struct {
-	Payload               *gloasPayloadSigningView
-	ExecutionRequests     *gloasExecutionRequestsSigningView
+type legacyGloasEnvelopeSigningView struct {
+	Payload               *legacyGloasPayloadSigningView
+	ExecutionRequests     *legacyGloasExecutionRequestsSigningView
 	BuilderIndex          gloas.BuilderIndex
 	BeaconBlockRoot       phase0.Root `ssz-size:"32"`
 	ParentBeaconBlockRoot phase0.Root `ssz-size:"32"`
 }
 
-func hashGloasEnvelope(envelope *eth2all.ExecutionPayloadEnvelope) (phase0.Root, error) {
+func hashLegacyGloasEnvelope(envelope *eth2all.ExecutionPayloadEnvelope) (phase0.Root, error) {
 	payload := envelope.Payload
 	requests := envelope.ExecutionRequests
 	if payload == nil || requests == nil {
 		return phase0.Root{}, fmt.Errorf("gloas envelope payload and execution requests are required")
 	}
 
-	view := &gloasEnvelopeSigningView{
-		Payload: &gloasPayloadSigningView{
+	view := &legacyGloasEnvelopeSigningView{
+		Payload: &legacyGloasPayloadSigningView{
 			ParentHash:      payload.ParentHash,
 			FeeRecipient:    payload.FeeRecipient,
 			StateRoot:       payload.StateRoot,
@@ -209,7 +237,7 @@ func hashGloasEnvelope(envelope *eth2all.ExecutionPayloadEnvelope) (phase0.Root,
 			BlockAccessList: payload.BlockAccessList,
 			SlotNumber:      payload.SlotNumber,
 		},
-		ExecutionRequests: &gloasExecutionRequestsSigningView{
+		ExecutionRequests: &legacyGloasExecutionRequestsSigningView{
 			Deposits:        requests.Deposits,
 			Withdrawals:     requests.Withdrawals,
 			Consolidations:  requests.Consolidations,

--- a/pkg/payload_bidder/signer.go
+++ b/pkg/payload_bidder/signer.go
@@ -15,7 +15,12 @@ import (
 	"fmt"
 
 	eth2all "github.com/ethpandaops/go-eth2-client/spec/all"
+	"github.com/ethpandaops/go-eth2-client/spec/bellatrix"
+	"github.com/ethpandaops/go-eth2-client/spec/capella"
+	"github.com/ethpandaops/go-eth2-client/spec/deneb"
+	"github.com/ethpandaops/go-eth2-client/spec/gloas"
 	"github.com/ethpandaops/go-eth2-client/spec/phase0"
+	"github.com/ethpandaops/go-eth2-client/spec/version"
 	dynssz "github.com/pk910/dynamic-ssz"
 
 	"github.com/ethpandaops/buildoor/pkg/signer"
@@ -42,6 +47,15 @@ func (s *Signer) SignBid(
 	forkVersion phase0.Version,
 	genesisValidatorsRoot phase0.Root,
 ) (phase0.BLSSignature, error) {
+	if bid.Version == version.DataVersionGloas {
+		root, err := hashGloasBid(bid)
+		if err != nil {
+			return phase0.BLSSignature{}, err
+		}
+
+		return s.signRoot(root, forkVersion, genesisValidatorsRoot)
+	}
+
 	return s.sign(bid, forkVersion, genesisValidatorsRoot)
 }
 
@@ -51,6 +65,15 @@ func (s *Signer) SignEnvelope(
 	forkVersion phase0.Version,
 	genesisValidatorsRoot phase0.Root,
 ) (phase0.BLSSignature, error) {
+	if envelope.Version == version.DataVersionGloas {
+		root, err := hashGloasEnvelope(envelope)
+		if err != nil {
+			return phase0.BLSSignature{}, err
+		}
+
+		return s.signRoot(root, forkVersion, genesisValidatorsRoot)
+	}
+
 	return s.sign(envelope, forkVersion, genesisValidatorsRoot)
 }
 
@@ -70,8 +93,138 @@ func (s *Signer) sign(
 	var root phase0.Root
 
 	copy(root[:], msgRoot[:])
+	return s.signRoot(root, forkVersion, genesisValidatorsRoot)
+}
+
+func (s *Signer) signRoot(
+	root phase0.Root,
+	forkVersion phase0.Version,
+	genesisValidatorsRoot phase0.Root,
+) (phase0.BLSSignature, error) {
 
 	domain := signer.ComputeDomain(DomainBeaconBuilder, forkVersion, genesisValidatorsRoot)
 
 	return s.blsSigner.SignWithDomain(root, domain)
+}
+
+// gloasBidSigningView pins the Gloas commitments field to the bounded-list
+// schema used by the Glamsterdam consensus specification. go-eth2-client
+// v0.1.6 models this field as a progressive list, which produces a different
+// signing root even though its JSON and wire fields are otherwise identical.
+type gloasBidSigningView struct {
+	ParentBlockHash       phase0.Hash32              `ssz-size:"32"`
+	ParentBlockRoot       phase0.Root                `ssz-size:"32"`
+	BlockHash             phase0.Hash32              `ssz-size:"32"`
+	PrevRandao            phase0.Root                `ssz-size:"32"`
+	FeeRecipient          bellatrix.ExecutionAddress `ssz-size:"20"`
+	GasLimit              uint64
+	BuilderIndex          gloas.BuilderIndex
+	Slot                  phase0.Slot
+	Value                 phase0.Gwei
+	ExecutionPayment      phase0.Gwei
+	BlobKZGCommitments    []deneb.KZGCommitment `ssz-max:"4096" ssz-size:"?,48"`
+	ExecutionRequestsRoot phase0.Root           `ssz-size:"32"`
+}
+
+func hashGloasBid(bid *eth2all.ExecutionPayloadBid) (phase0.Root, error) {
+	view := &gloasBidSigningView{
+		ParentBlockHash:       bid.ParentBlockHash,
+		ParentBlockRoot:       bid.ParentBlockRoot,
+		BlockHash:             bid.BlockHash,
+		PrevRandao:            bid.PrevRandao,
+		FeeRecipient:          bid.FeeRecipient,
+		GasLimit:              bid.GasLimit,
+		BuilderIndex:          bid.BuilderIndex,
+		Slot:                  bid.Slot,
+		Value:                 bid.Value,
+		ExecutionPayment:      bid.ExecutionPayment,
+		BlobKZGCommitments:    bid.BlobKZGCommitments,
+		ExecutionRequestsRoot: bid.ExecutionRequestsRoot,
+	}
+
+	root, err := dynssz.GetGlobalDynSsz().HashTreeRoot(view)
+	if err != nil {
+		return phase0.Root{}, fmt.Errorf("failed to compute Gloas bid hash tree root: %w", err)
+	}
+
+	return phase0.Root(root), nil
+}
+
+type gloasPayloadSigningView struct {
+	ParentHash      phase0.Hash32              `ssz-size:"32"`
+	FeeRecipient    bellatrix.ExecutionAddress `ssz-size:"20"`
+	StateRoot       phase0.Root                `ssz-size:"32"`
+	ReceiptsRoot    phase0.Root                `ssz-size:"32"`
+	LogsBloom       [256]byte                  `ssz-size:"256"`
+	PrevRandao      [32]byte                   `ssz-size:"32"`
+	BlockNumber     uint64
+	GasLimit        uint64
+	GasUsed         uint64
+	Timestamp       uint64
+	ExtraData       []byte `ssz-max:"32"`
+	BaseFeePerGas   [32]byte
+	BlockHash       phase0.Hash32           `ssz-size:"32"`
+	Transactions    []bellatrix.Transaction `ssz-max:"1048576,1073741824" ssz-size:"?,?"`
+	Withdrawals     []*capella.Withdrawal   `ssz-max:"16"`
+	BlobGasUsed     uint64
+	ExcessBlobGas   uint64
+	BlockAccessList gloas.BlockAccessList `ssz-max:"1073741824"`
+	SlotNumber      uint64
+}
+
+type gloasEnvelopeSigningView struct {
+	Payload               *gloasPayloadSigningView
+	ExecutionRequests     *gloasExecutionRequestsSigningView
+	BuilderIndex          gloas.BuilderIndex
+	BeaconBlockRoot       phase0.Root `ssz-size:"32"`
+	ParentBeaconBlockRoot phase0.Root `ssz-size:"32"`
+}
+
+func hashGloasEnvelope(envelope *eth2all.ExecutionPayloadEnvelope) (phase0.Root, error) {
+	payload := envelope.Payload
+	requests := envelope.ExecutionRequests
+	if payload == nil || requests == nil {
+		return phase0.Root{}, fmt.Errorf("Gloas envelope payload and execution requests are required")
+	}
+
+	view := &gloasEnvelopeSigningView{
+		Payload: &gloasPayloadSigningView{
+			ParentHash:      payload.ParentHash,
+			FeeRecipient:    payload.FeeRecipient,
+			StateRoot:       payload.StateRoot,
+			ReceiptsRoot:    payload.ReceiptsRoot,
+			LogsBloom:       payload.LogsBloom,
+			PrevRandao:      payload.PrevRandao,
+			BlockNumber:     payload.BlockNumber,
+			GasLimit:        payload.GasLimit,
+			GasUsed:         payload.GasUsed,
+			Timestamp:       payload.Timestamp,
+			ExtraData:       payload.ExtraData,
+			BaseFeePerGas:   payload.BaseFeePerGasLE,
+			BlockHash:       payload.BlockHash,
+			Transactions:    payload.Transactions,
+			Withdrawals:     payload.Withdrawals,
+			BlobGasUsed:     payload.BlobGasUsed,
+			ExcessBlobGas:   payload.ExcessBlobGas,
+			BlockAccessList: payload.BlockAccessList,
+			SlotNumber:      payload.SlotNumber,
+		},
+		ExecutionRequests: &gloasExecutionRequestsSigningView{
+			Deposits:        requests.Deposits,
+			Withdrawals:     requests.Withdrawals,
+			Consolidations:  requests.Consolidations,
+			BuilderDeposits: requests.BuilderDeposits,
+			BuilderExits:    requests.BuilderExits,
+		},
+		BuilderIndex:          envelope.BuilderIndex,
+		BeaconBlockRoot:       envelope.BeaconBlockRoot,
+		ParentBeaconBlockRoot: envelope.ParentBeaconBlockRoot,
+	}
+
+	root, err := dynssz.GetGlobalDynSsz().HashTreeRoot(view)
+	if err != nil {
+		return phase0.Root{}, fmt.Errorf("failed to compute Gloas envelope hash tree root: %w", err)
+	}
+
+	return phase0.Root(root), nil
 }

--- a/pkg/payload_bidder/signer.go
+++ b/pkg/payload_bidder/signer.go
@@ -184,7 +184,7 @@ func hashGloasEnvelope(envelope *eth2all.ExecutionPayloadEnvelope) (phase0.Root,
 	payload := envelope.Payload
 	requests := envelope.ExecutionRequests
 	if payload == nil || requests == nil {
-		return phase0.Root{}, fmt.Errorf("Gloas envelope payload and execution requests are required")
+		return phase0.Root{}, fmt.Errorf("gloas envelope payload and execution requests are required")
 	}
 
 	view := &gloasEnvelopeSigningView{

--- a/pkg/payload_bidder/signer_test.go
+++ b/pkg/payload_bidder/signer_test.go
@@ -9,10 +9,26 @@ import (
 	"github.com/ethpandaops/go-eth2-client/spec/gloas"
 	"github.com/ethpandaops/go-eth2-client/spec/phase0"
 	"github.com/ethpandaops/go-eth2-client/spec/version"
+	dynssz "github.com/pk910/dynamic-ssz"
 	"github.com/stretchr/testify/require"
 )
 
-func TestGloasBidUsesBoundedCommitmentsListRoot(t *testing.T) {
+func TestSignerDefaultsToProgressiveGloasSSZ(t *testing.T) {
+	requests := &eth2all.ExecutionRequests{Version: version.DataVersionGloas}
+
+	want, err := dynssz.GetGlobalDynSsz().HashTreeRoot(requests)
+	require.NoError(t, err)
+
+	got, err := NewSigner(nil).hashExecutionRequests(requests)
+	require.NoError(t, err)
+	require.Equal(t, phase0.Root(want), got)
+
+	legacy, err := NewSigner(nil, WithLegacyGloasSSZ(true)).hashExecutionRequests(requests)
+	require.NoError(t, err)
+	require.NotEqual(t, got, legacy)
+}
+
+func TestLegacyGloasBidUsesBoundedCommitmentsListRoot(t *testing.T) {
 	decode := func(value string) []byte {
 		decoded, err := hex.DecodeString(value)
 		require.NoError(t, err)
@@ -39,7 +55,7 @@ func TestGloasBidUsesBoundedCommitmentsListRoot(t *testing.T) {
 		ExecutionRequestsRoot: root("87b69a306c8e430d0857f7c4ac5e27cecffa1108d43c2e5df7388056fea7a423"),
 	}
 
-	actual, err := hashGloasBid(bid)
+	actual, err := hashLegacyGloasBid(bid)
 	require.NoError(t, err)
 	require.Equal(t,
 		"05443306d810e015f5c790dc4be85203a1b7d1c9e4e5819e711c8b730500a598",
@@ -47,8 +63,8 @@ func TestGloasBidUsesBoundedCommitmentsListRoot(t *testing.T) {
 	)
 }
 
-func TestGloasExecutionRequestsUseBoundedListRoots(t *testing.T) {
-	actual, err := hashGloasExecutionRequests(&eth2all.ExecutionRequests{
+func TestLegacyGloasExecutionRequestsUseBoundedListRoots(t *testing.T) {
+	actual, err := hashLegacyGloasExecutionRequests(&eth2all.ExecutionRequests{
 		Version: version.DataVersionGloas,
 	})
 	require.NoError(t, err)
@@ -58,8 +74,8 @@ func TestGloasExecutionRequestsUseBoundedListRoots(t *testing.T) {
 	)
 }
 
-func TestGloasEnvelopeUsesBoundedNestedListRoots(t *testing.T) {
-	actual, err := hashGloasEnvelope(&eth2all.ExecutionPayloadEnvelope{
+func TestLegacyGloasEnvelopeUsesBoundedNestedListRoots(t *testing.T) {
+	actual, err := hashLegacyGloasEnvelope(&eth2all.ExecutionPayloadEnvelope{
 		Version:           version.DataVersionGloas,
 		Payload:           &eth2all.ExecutionPayload{Version: version.DataVersionGloas},
 		ExecutionRequests: &eth2all.ExecutionRequests{Version: version.DataVersionGloas},

--- a/pkg/payload_bidder/signer_test.go
+++ b/pkg/payload_bidder/signer_test.go
@@ -1,0 +1,74 @@
+package payload_bidder
+
+import (
+	"encoding/hex"
+	"testing"
+
+	eth2all "github.com/ethpandaops/go-eth2-client/spec/all"
+	"github.com/ethpandaops/go-eth2-client/spec/bellatrix"
+	"github.com/ethpandaops/go-eth2-client/spec/gloas"
+	"github.com/ethpandaops/go-eth2-client/spec/phase0"
+	"github.com/ethpandaops/go-eth2-client/spec/version"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGloasBidUsesBoundedCommitmentsListRoot(t *testing.T) {
+	decode := func(value string) []byte {
+		decoded, err := hex.DecodeString(value)
+		require.NoError(t, err)
+		return decoded
+	}
+	root := func(value string) (result phase0.Root) {
+		copy(result[:], decode(value))
+		return result
+	}
+
+	bid := &eth2all.ExecutionPayloadBid{
+		Version:               version.DataVersionGloas,
+		ParentBlockHash:       phase0.Hash32(root("882d22ed3a133fd42ba744661121f750e5bfa32fbdd5f08025f2356ff2d56962")),
+		ParentBlockRoot:       root("9474a47b8c7f35d85a5f59b6fb25e17471aa37ee228ecc3292d0e8551e84fa6b"),
+		BlockHash:             phase0.Hash32(root("7396438bc6390d1ef45bd0b842cfad8c3e782abbfb5381e6d9def8cef3d15a91")),
+		PrevRandao:            root("a86033297239e33101fccfaca4217a0ee291d957dbd86ab46211f70b53c0e0c5"),
+		FeeRecipient:          bellatrix.ExecutionAddress(decode("8943545177806ed17b9f23f0a21ee5948ecaa776")),
+		GasLimit:              150000000,
+		BuilderIndex:          gloas.BuilderIndex(0),
+		Slot:                  180,
+		Value:                 100000,
+		ExecutionPayment:      0,
+		BlobKZGCommitments:    nil,
+		ExecutionRequestsRoot: root("87b69a306c8e430d0857f7c4ac5e27cecffa1108d43c2e5df7388056fea7a423"),
+	}
+
+	actual, err := hashGloasBid(bid)
+	require.NoError(t, err)
+	require.Equal(t,
+		"05443306d810e015f5c790dc4be85203a1b7d1c9e4e5819e711c8b730500a598",
+		hex.EncodeToString(actual[:]),
+	)
+}
+
+func TestGloasExecutionRequestsUseBoundedListRoots(t *testing.T) {
+	actual, err := hashGloasExecutionRequests(&eth2all.ExecutionRequests{
+		Version: version.DataVersionGloas,
+	})
+	require.NoError(t, err)
+	require.Equal(t,
+		"3a02ed03ab3f2af7ef0e6ee1a44326479d2ab1d2f03613dd1ec0a11fcf37af96",
+		hex.EncodeToString(actual[:]),
+	)
+}
+
+func TestGloasEnvelopeUsesBoundedNestedListRoots(t *testing.T) {
+	actual, err := hashGloasEnvelope(&eth2all.ExecutionPayloadEnvelope{
+		Version:           version.DataVersionGloas,
+		Payload:           &eth2all.ExecutionPayload{Version: version.DataVersionGloas},
+		ExecutionRequests: &eth2all.ExecutionRequests{Version: version.DataVersionGloas},
+		BuilderIndex:      gloas.BuilderIndex(0),
+		BeaconBlockRoot:   phase0.Root{0x11},
+	})
+	require.NoError(t, err)
+	require.Equal(t,
+		"743eaf4d36852670927ebaa1cd7893ce86b0da831ad2da818bcb5dd740e1e546",
+		hex.EncodeToString(actual[:]),
+	)
+}


### PR DESCRIPTION
## Why this is needed

Buildoor main intentionally targets Glamsterdam devnet-7 and EIP-7688 progressive SSZ (see #126). TYSM currently uses the stable Glamsterdam devnet-6 specs for its reproducible fault-injection tests; devnet-6 still uses bounded lists and binary containers. A Buildoor binary using only the devnet-7 roots produces invalid bid/envelope signatures against that devnet-6 client.

This PR supports that stable-spec test case without rolling Buildoor back: progressive SSZ remains the default, while `--epbs-legacy-gloas-ssz` explicitly selects the devnet-6 bounded schema for the p2p bid/reveal path. The accompanying TYSM Kurtosis experiment enables the flag explicitly.

The experiment also exposed three independent runtime problems: Buildoor could query `/config/spec` before the beacon client considered itself active, recomputing a Gloas block root through a mismatched library schema could make a valid reveal reference look unknown, and an absent execution-request object could prevent envelope construction.

## What changed

- retain EIP-7688 progressive SSZ as the default
- add opt-in `--epbs-legacy-gloas-ssz` compatibility for devnet-6 bid, execution-request, payload, and envelope roots
- preserve the canonical beacon root from head events when tracking an included bid
- normalize absent execution requests before constructing an envelope
- retry global SSZ initialization while a beacon node is still becoming ready
- test that the default still routes through progressive SSZ and pin the legacy roots used by devnet-6

## Verification

- `go test ./...`
- `go vet ./...`
- local Kurtosis network using Glamsterdam devnet-6 specs/images: 61 accepted bid slots and 48 accepted payload reveals after enabling the compatibility mode, with no further submission or reveal failures

Related TYSM experiment: ethpandaops/tysm#51
