### PR TITLE
small fixes

### DIFF
--- a/.github/workflows/_shared-check.yaml
+++ b/.github/workflows/_shared-check.yaml
@@ -1,4 +1,3 @@
-
 name: Reusable check workflow
 on:
   workflow_call:
@@ -6,7 +5,8 @@ on:
 permissions:
   contents: read
 
-# shared check jobs
+# shared check jobs (code checks only — the Kurtosis E2E lives in
+# _shared-e2e.yaml and runs on PRs only, not on branch builds)
 jobs:
   check_source:
     name: Run code checks
@@ -34,7 +34,7 @@ jobs:
           webui-npm-${{ runner.os }}-
           webui-npm-
 
-    # build UI package
+    # build UI package (the bundle is gitignored and go:embed needs it)
     - name: Build UI package
       run: |
         make build-ui
@@ -60,32 +60,3 @@ jobs:
 
     - name: Run tests
       run: go test -race -vet=off ./...
-
-    # Reuse the UI built above and package the resulting binary in the runtime-only image.
-    - name: Build Buildoor binary for E2E
-      run: make build
-
-    - name: Build E2E runtime image
-      run: docker build --file Dockerfile-stub --tag buildoor:e2e .
-
-    - name: Install Kurtosis
-      run: |
-        echo "deb [trusted=yes] https://sdk.kurtosis.com/kurtosis-cli-release-artifacts/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
-        sudo apt-get update
-        sudo apt-get install --yes kurtosis-cli jq
-        kurtosis analytics disable
-
-    - name: Run Kurtosis E2E
-      run: .github/scripts/e2e-kurtosis.sh
-      env:
-        ENCLAVE_NAME: buildoor-e2e-${{ github.run_id }}-${{ github.run_attempt }}
-        ARTIFACT_DIR: ${{ runner.temp }}/buildoor-e2e
-
-    - name: Upload Kurtosis diagnostics
-      if: always()
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-      with:
-        name: kurtosis-e2e-${{ github.run_id }}-${{ github.run_attempt }}
-        path: ${{ runner.temp }}/buildoor-e2e
-        if-no-files-found: warn
-        retention-days: 7

--- a/.github/workflows/_shared-e2e.yaml
+++ b/.github/workflows/_shared-e2e.yaml
@@ -1,0 +1,69 @@
+name: Reusable E2E workflow
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+# Kurtosis devnet E2E — expensive (multi-client enclave), so it is wired
+# into the PR check only; branch builds (main/dev/release) skip it.
+jobs:
+  e2e_kurtosis:
+    name: Run Kurtosis E2E
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+    # setup global dependencies
+    - name: Set up go
+      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+      with:
+        go-version: 1.25.x
+    - name: Set up node
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      with:
+        node-version: 20.x
+    - name: Cache node-modules for UI package
+      id: cache-npm
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ./pkg/webui/node_modules
+        key: webui-npm-${{ runner.os }}-${{ hashFiles('./pkg/webui/package-lock.json') }}
+        restore-keys: |
+          webui-npm-${{ runner.os }}-
+          webui-npm-
+
+    # build UI package
+    - name: Build UI package
+      run: |
+        make build-ui
+
+    # Package the binary in the runtime-only image.
+    - name: Build Buildoor binary for E2E
+      run: make build
+
+    - name: Build E2E runtime image
+      run: docker build --file Dockerfile-stub --tag buildoor:e2e .
+
+    - name: Install Kurtosis
+      run: |
+        echo "deb [trusted=yes] https://sdk.kurtosis.com/kurtosis-cli-release-artifacts/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
+        sudo apt-get update
+        sudo apt-get install --yes kurtosis-cli jq
+        kurtosis analytics disable
+
+    - name: Run Kurtosis E2E
+      run: .github/scripts/e2e-kurtosis.sh
+      env:
+        ENCLAVE_NAME: buildoor-e2e-${{ github.run_id }}-${{ github.run_attempt }}
+        ARTIFACT_DIR: ${{ runner.temp }}/buildoor-e2e
+
+    - name: Upload Kurtosis diagnostics
+      if: always()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: kurtosis-e2e-${{ github.run_id }}-${{ github.run_attempt }}
+        path: ${{ runner.temp }}/buildoor-e2e
+        if-no-files-found: warn
+        retention-days: 7

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -18,3 +18,11 @@ jobs:
     name: "Run code checks"
     uses: ./.github/workflows/_shared-check.yaml
 
+  # The Kurtosis E2E runs on PRs only (branch builds reuse _shared-check.yaml
+  # without it); gated on the code checks so broken code never spins up an
+  # enclave.
+  e2e:
+    name: "Run E2E test"
+    needs: [check_source]
+    uses: ./.github/workflows/_shared-e2e.yaml
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -273,7 +273,10 @@ npm run clean
      recover at ≥90%) sets the `Low` flag on the `vote_coverage` SSE event
      (initial-state + on change) — the UI then shows a warning badge (hover
      callout with the subscribe-all-subnets flags) in the Slot Timeline
-     header and hides the head-vote graph as unreliable
+     header and hides the head-vote graph. Low coverage makes BOTH the graph
+     AND vote-threshold-gated reveals unreliable: the undercounted
+     participation opens reveal vote gates late or never (withheld at slot
+     end)
 
 4. **Lifecycle Manager** (`pkg/lifecycle/`)
    - Builder registration on beacon chain

--- a/pkg/chain/headvotes.go
+++ b/pkg/chain/headvotes.go
@@ -178,11 +178,11 @@ func NewHeadVoteTracker(
 	log logrus.FieldLogger,
 ) *HeadVoteTracker {
 	return &HeadVoteTracker{
-		cfg:                   cfg,
-		chainSvc:              chainSvc,
-		clClient:              clClient,
-		log:                   log.WithField("component", "head-vote-tracker"),
-		slotStates:            make(map[phase0.Slot]*slotVoteState, voteSlotRetention),
+		cfg:                cfg,
+		chainSvc:           chainSvc,
+		clClient:           clClient,
+		log:                log.WithField("component", "head-vote-tracker"),
+		slotStates:         make(map[phase0.Slot]*slotVoteState, voteSlotRetention),
 		coverageSamples:    make([]coverageSample, 0, coverageWindowSlots),
 		updateDispatcher:   &utils.Dispatcher[*HeadVoteUpdate]{},
 		coverageDispatcher: &utils.Dispatcher[*SubnetCoverage]{},

--- a/pkg/chain/headvotes.go
+++ b/pkg/chain/headvotes.go
@@ -8,6 +8,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	eth2all "github.com/ethpandaops/go-eth2-client/spec/all"
 	"github.com/ethpandaops/go-eth2-client/spec/phase0"
 	"github.com/sirupsen/logrus"
 
@@ -162,6 +163,7 @@ type HeadVoteTracker struct {
 
 	updateDispatcher   *utils.Dispatcher[*HeadVoteUpdate]
 	coverageDispatcher *utils.Dispatcher[*SubnetCoverage]
+	blockDispatcher    *utils.Dispatcher[*eth2all.SignedBeaconBlock]
 
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -176,14 +178,15 @@ func NewHeadVoteTracker(
 	log logrus.FieldLogger,
 ) *HeadVoteTracker {
 	return &HeadVoteTracker{
-		cfg:                cfg,
-		chainSvc:           chainSvc,
-		clClient:           clClient,
-		log:                log.WithField("component", "head-vote-tracker"),
-		slotStates:         make(map[phase0.Slot]*slotVoteState, voteSlotRetention),
+		cfg:                   cfg,
+		chainSvc:              chainSvc,
+		clClient:              clClient,
+		log:                   log.WithField("component", "head-vote-tracker"),
+		slotStates:            make(map[phase0.Slot]*slotVoteState, voteSlotRetention),
 		coverageSamples:    make([]coverageSample, 0, coverageWindowSlots),
 		updateDispatcher:   &utils.Dispatcher[*HeadVoteUpdate]{},
 		coverageDispatcher: &utils.Dispatcher[*SubnetCoverage]{},
+		blockDispatcher:    &utils.Dispatcher[*eth2all.SignedBeaconBlock]{},
 	}
 }
 
@@ -216,6 +219,14 @@ func (t *HeadVoteTracker) SubscribeUpdates() *utils.Subscription[*HeadVoteUpdate
 // (at most one per imported block).
 func (t *HeadVoteTracker) SubscribeCoverage() *utils.Subscription[*SubnetCoverage] {
 	return t.coverageDispatcher.Subscribe(16, false)
+}
+
+// SubscribeBlocks returns a subscription for imported blocks (the full
+// fork-agnostic signed block — a byproduct of the coverage measurement's
+// block fetch; at most one per imported block, none while a fetch is still
+// in flight). Consumers reduce it to whatever shape they need.
+func (t *HeadVoteTracker) SubscribeBlocks() *utils.Subscription[*eth2all.SignedBeaconBlock] {
+	return t.blockDispatcher.Subscribe(16, false)
 }
 
 // GetSubnetCoverage returns the current subnet coverage summary.
@@ -416,13 +427,17 @@ func (t *HeadVoteTracker) measureBlockCoverage(root phase0.Root) {
 	ctx, cancel := context.WithTimeout(t.ctx, 5*time.Second)
 	defer cancel()
 
-	atts, err := t.clClient.GetBlockAttestations(ctx, fmt.Sprintf("%#x", root))
+	block, err := t.clClient.GetSignedBlock(ctx, fmt.Sprintf("%#x", root))
 	if err != nil {
-		t.log.WithError(err).Debug("Failed to fetch block attestations for coverage measurement")
+		t.log.WithError(err).Debug("Failed to fetch block for coverage measurement")
 		return
 	}
 
-	t.recordBlockAttestations(atts)
+	t.recordBlockAttestations(beacon.BlockAttestationEvents(block))
+
+	// The same fetch yields the full block — forward it (e.g. to the WebUI's
+	// Block Received callout) instead of fetching twice.
+	t.blockDispatcher.Fire(block)
 }
 
 // recordBlockAttestations compares a block's attesters against the singles

--- a/pkg/chain/headvotes.go
+++ b/pkg/chain/headvotes.go
@@ -506,7 +506,8 @@ func (t *HeadVoteTracker) recordBlockAttestations(atts []*beacon.AttestationEven
 			"seen_pct":  fmt.Sprintf("%.1f%%", cov.SeenPct),
 			"attesters": cov.Attesters,
 		}).Warn("Raw attestation subnet coverage is low — beacon node likely runs " +
-			"without subscribe-all-subnets; head vote tracking is unreliable")
+			"without subscribe-all-subnets; head vote tracking undercounts and " +
+			"vote-threshold-gated reveals are unreliable (gates open late or never)")
 	} else if t.coverageLow && cov.SeenPct >= coverageRecoverThreshold {
 		t.coverageLow = false
 

--- a/pkg/payload_builder/attributes_fallback_test.go
+++ b/pkg/payload_builder/attributes_fallback_test.go
@@ -1,0 +1,137 @@
+package payload_builder
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethpandaops/go-eth2-client/spec/phase0"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethpandaops/buildoor/pkg/action_plan"
+	"github.com/ethpandaops/buildoor/pkg/chain"
+	"github.com/ethpandaops/buildoor/pkg/config"
+	"github.com/ethpandaops/buildoor/pkg/rpc/beacon"
+)
+
+// TestApplyAttributesFallback re-uses the parent slot's payload attributes
+// when a slot's block is missing entirely and the beacon node never emitted
+// fresh attributes: only the proposal slot and timestamp advance.
+func TestApplyAttributesFallback(t *testing.T) {
+	cfg := config.DefaultConfig()
+
+	chainSvc := &stubChainService{spec: &chain.ChainSpec{
+		SecondsPerSlot: 12 * time.Second,
+		SlotsPerEpoch:  32,
+	}}
+
+	log := logrus.New()
+	log.SetLevel(logrus.ErrorLevel)
+
+	// The client never connects (delayed start); only its event stream is used.
+	clClient, err := beacon.NewClient(context.Background(), "http://127.0.0.1:1", log)
+	require.NoError(t, err)
+
+	planSvc := action_plan.NewPlanService(cfg, chainSvc, log)
+
+	svc, err := NewService(cfg, clClient, chainSvc, planSvc, nil, common.Address{}, log)
+	require.NoError(t, err)
+
+	svc.ctx = context.Background()
+
+	events := clClient.Events()
+	parent := &beacon.PayloadAttributesEvent{
+		Version:           "gloas",
+		ProposalSlot:      20,
+		ProposerIndex:     7,
+		ParentBlockRoot:   phase0.Root{0xbb},
+		ParentBlockNumber: 15,
+		ParentBlockHash:   phase0.Hash32{0xaa},
+		Timestamp:         1000,
+		PrevRandao:        phase0.Root{0xcc},
+	}
+	require.True(t, events.InjectPayloadAttributes(parent))
+
+	sub := events.SubscribePayloadAttributes()
+	defer sub.Unsubscribe()
+
+	svc.applyAttributesFallback(21)
+
+	synthesized := events.GetLatestPayloadAttributes(21)
+	require.NotNil(t, synthesized, "fallback must synthesize attributes for the empty slot")
+	assert.Equal(t, phase0.Slot(21), synthesized.ProposalSlot)
+	assert.Equal(t, uint64(1012), synthesized.Timestamp, "timestamp advances one slot")
+	assert.Equal(t, parent.ParentBlockHash, synthesized.ParentBlockHash, "parent unchanged: no new block on top")
+	assert.Equal(t, parent.ParentBlockRoot, synthesized.ParentBlockRoot)
+	assert.Equal(t, parent.ParentBlockNumber, synthesized.ParentBlockNumber)
+	assert.Equal(t, parent.PrevRandao, synthesized.PrevRandao)
+
+	select {
+	case got := <-sub.Channel():
+		assert.Equal(t, phase0.Slot(21), got.ProposalSlot, "synthesized event must be dispatched")
+	default:
+		t.Fatal("expected the synthesized event on the dispatcher")
+	}
+
+	// With attributes now present, a second fallback run must not dispatch again.
+	svc.applyAttributesFallback(21)
+
+	select {
+	case <-sub.Channel():
+		t.Fatal("fallback must not re-dispatch when attributes exist")
+	default:
+	}
+
+	// Without parent attributes there is nothing to synthesize from.
+	svc.applyAttributesFallback(30)
+	assert.Nil(t, events.GetLatestPayloadAttributes(30))
+}
+
+// TestApplyAttributesFallbackMultiSlotGap covers runs of consecutive missing
+// blocks: the last available attributes are used and the timestamp advances
+// by the number of skipped slots.
+func TestApplyAttributesFallbackMultiSlotGap(t *testing.T) {
+	cfg := config.DefaultConfig()
+
+	chainSvc := &stubChainService{spec: &chain.ChainSpec{
+		SecondsPerSlot: 12 * time.Second,
+		SlotsPerEpoch:  32,
+	}}
+
+	log := logrus.New()
+	log.SetLevel(logrus.ErrorLevel)
+
+	clClient, err := beacon.NewClient(context.Background(), "http://127.0.0.1:1", log)
+	require.NoError(t, err)
+
+	planSvc := action_plan.NewPlanService(cfg, chainSvc, log)
+
+	svc, err := NewService(cfg, clClient, chainSvc, planSvc, nil, common.Address{}, log)
+	require.NoError(t, err)
+
+	svc.ctx = context.Background()
+
+	events := clClient.Events()
+	require.True(t, events.InjectPayloadAttributes(&beacon.PayloadAttributesEvent{
+		ProposalSlot:    40,
+		Timestamp:       2000,
+		ParentBlockHash: phase0.Hash32{0xdd},
+	}))
+
+	// Slots 41-43 are all missing: the fallback for 43 reaches back to 40.
+	svc.applyAttributesFallback(43)
+
+	synthesized := events.GetLatestPayloadAttributes(43)
+	require.NotNil(t, synthesized)
+	assert.Equal(t, phase0.Slot(43), synthesized.ProposalSlot)
+	assert.Equal(t, uint64(2000+3*12), synthesized.Timestamp, "timestamp advances by the skipped slots")
+	assert.Equal(t, phase0.Hash32{0xdd}, synthesized.ParentBlockHash)
+
+	// Beyond the lookback window (past both slot 40 and the synthesized 43)
+	// nothing is synthesized.
+	svc.applyAttributesFallback(43 + attrFallbackLookback + 1)
+	assert.Nil(t, events.GetLatestPayloadAttributes(43+attrFallbackLookback+1))
+}

--- a/pkg/payload_builder/gaslimit.go
+++ b/pkg/payload_builder/gaslimit.go
@@ -1,0 +1,21 @@
+package payload_builder
+
+// expectedBidGasLimit returns the gas limit a Gloas execution payload bid
+// must commit to for gossip validation to accept it: the parent block's
+// committed gas limit moved toward the proposer's preferred target, clamped
+// to the maximum per-block adjustment of parent/1024 - 1. Any other value is
+// rejected with InvalidGasLimit, so an EL that builds toward a different
+// target produces unbiddable payloads unless the gas limit is adjusted to
+// this value.
+func expectedBidGasLimit(parentGasLimit, targetGasLimit uint64) uint64 {
+	maxDiff := max(parentGasLimit/1024, 1) - 1
+
+	switch {
+	case targetGasLimit > parentGasLimit && targetGasLimit-parentGasLimit > maxDiff:
+		return parentGasLimit + maxDiff
+	case targetGasLimit < parentGasLimit && parentGasLimit-targetGasLimit > maxDiff:
+		return parentGasLimit - maxDiff
+	default:
+		return targetGasLimit
+	}
+}

--- a/pkg/payload_builder/gaslimit_test.go
+++ b/pkg/payload_builder/gaslimit_test.go
@@ -1,0 +1,71 @@
+package payload_builder
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExpectedBidGasLimit(t *testing.T) {
+	tests := []struct {
+		name           string
+		parentGasLimit uint64
+		targetGasLimit uint64
+		expected       uint64
+	}{
+		{
+			name:           "target reachable within one step",
+			parentGasLimit: 300_000_000,
+			targetGasLimit: 300_000_000,
+			expected:       300_000_000,
+		},
+		{
+			name:           "target slightly above parent within bounds",
+			parentGasLimit: 299_903_641,
+			targetGasLimit: 300_000_000,
+			expected:       300_000_000,
+		},
+		{
+			name:           "target far above parent clamps to max step up",
+			parentGasLimit: 30_000_000,
+			targetGasLimit: 300_000_000,
+			expected:       30_000_000 + 30_000_000/1024 - 1,
+		},
+		{
+			name:           "target far below parent clamps to max step down",
+			parentGasLimit: 300_000_000,
+			targetGasLimit: 45_000_000,
+			expected:       300_000_000 - (300_000_000/1024 - 1),
+		},
+		{
+			name:           "target slightly below parent within bounds",
+			parentGasLimit: 300_000_000,
+			targetGasLimit: 299_900_000,
+			expected:       299_900_000,
+		},
+		{
+			name:           "boundary exactly at max diff up",
+			parentGasLimit: 1_024_000,
+			targetGasLimit: 1_024_000 + 999,
+			expected:       1_024_000 + 999,
+		},
+		{
+			name:           "boundary one above max diff up",
+			parentGasLimit: 1_024_000,
+			targetGasLimit: 1_024_000 + 1000,
+			expected:       1_024_000 + 999,
+		},
+		{
+			name:           "tiny parent has zero adjustment room",
+			parentGasLimit: 100,
+			targetGasLimit: 200,
+			expected:       100,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, expectedBidGasLimit(tt.parentGasLimit, tt.targetGasLimit))
+		})
+	}
+}

--- a/pkg/payload_builder/payload_builder.go
+++ b/pkg/payload_builder/payload_builder.go
@@ -230,6 +230,24 @@ func (b *PayloadBuilder) BuildPayloadFromAttributes(
 		"payload_id": fmt.Sprintf("%x", payloadID[:]),
 	}).Debug("Payload build requested from attributes")
 
+	// Resolve the gas limit the slot's bid must commit to while the EL
+	// accumulates transactions. Bid gossip validation compares against the
+	// parent block's committed gas limit moved toward the proposer's target
+	// at the maximum per-block step; an EL that ignores the targetGasLimit
+	// payload attribute builds toward its own configured target instead, so
+	// the built payload's gas limit is corrected to the expected value below.
+	var expectedGasLimit uint64
+
+	if beaconFork >= version.DataVersionGloas && targetGasLimit > 0 {
+		parentInfo, err := b.clClient.GetBlockInfo(buildCtx, fmt.Sprintf("%#x", attrs.ParentBlockRoot[:]))
+		if err != nil {
+			b.log.WithError(err).WithField("slot", attrs.ProposalSlot).
+				Warn("Failed to fetch parent block gas limit, keeping EL gas limit")
+		} else {
+			expectedGasLimit = expectedBidGasLimit(parentInfo.GasLimit, targetGasLimit)
+		}
+	}
+
 	// Read the build time live from config so UI overrides take effect immediately.
 	payloadBuildTime := b.cfg.PayloadBuildTime
 
@@ -258,15 +276,41 @@ func (b *PayloadBuilder) BuildPayloadFromAttributes(
 		return nil, fmt.Errorf("getPayload returned no execution payload")
 	}
 
-	// Inject our extra-data marker and recompute the block hash on the typed payload.
-	newHash, err := ModifyPayloadExtraData(
+	// Correct the payload gas limit when the EL built with a different one
+	// than the bid must commit to. Raising it is always safe; lowering it is
+	// impossible once the EL packed more gas than the expected limit allows.
+	var gasLimitOverride uint64
+
+	if expectedGasLimit > 0 && enginePayload.GasLimit != expectedGasLimit {
+		if enginePayload.GasUsed > expectedGasLimit {
+			b.log.WithFields(logrus.Fields{
+				"slot":               attrs.ProposalSlot,
+				"el_gas_limit":       enginePayload.GasLimit,
+				"expected_gas_limit": expectedGasLimit,
+				"gas_used":           enginePayload.GasUsed,
+			}).Warn("Cannot adjust payload gas limit below gas used, bid will fail gossip validation")
+		} else {
+			gasLimitOverride = expectedGasLimit
+
+			b.log.WithFields(logrus.Fields{
+				"slot":               attrs.ProposalSlot,
+				"el_gas_limit":       enginePayload.GasLimit,
+				"expected_gas_limit": expectedGasLimit,
+			}).Info("Adjusting payload gas limit to expected bid gas limit")
+		}
+	}
+
+	// Inject our extra-data marker (and the gas limit correction) and
+	// recompute the block hash on the typed payload.
+	newHash, err := ModifyPayload(
 		enginePayload,
 		resp.ExecutionRequests,
 		[]byte(b.cfg.ExtraData),
+		gasLimitOverride,
 		common.Hash(attrs.ParentBeaconBlockRoot),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to modify payload extra data: %w", err)
+		return nil, fmt.Errorf("failed to modify payload: %w", err)
 	}
 
 	// Single fork-independent conversions to the beacon types: the execution

--- a/pkg/payload_builder/payload_modifier.go
+++ b/pkg/payload_builder/payload_modifier.go
@@ -17,10 +17,14 @@ import (
 
 const maxExtraDataSize = 32
 
-// ModifyPayloadExtraData rewrites the extraData field of a built execution
-// payload in place, prepending the given prefix (truncating the original to
-// stay within the 32-byte limit), recomputes the block hash, updates the
-// payload's BlockHash field, and returns the new hash.
+// ModifyPayload rewrites header-only fields of a built execution payload in
+// place and recomputes the block hash: the extraData field gets the given
+// prefix prepended (truncating the original to stay within the 32-byte
+// limit), and a non-zero gasLimitOverride replaces the gas limit the EL built
+// with (used when the EL ignores the requested target gas limit; the caller
+// must ensure the override stays >= gasUsed and within the EIP-1559 bounds of
+// the parent). The payload's BlockHash field is updated and the new hash
+// returned.
 //
 // The parentBeaconBlockRoot is required because it is part of the block header
 // (and therefore affects the block hash) but is not carried in the execution
@@ -33,10 +37,11 @@ const maxExtraDataSize = 32
 // The function first verifies it can reconstruct the original block hash from
 // the payload fields. If verification fails (e.g. an unhandled fork added new
 // header fields) it returns an error rather than producing an incorrect hash.
-func ModifyPayloadExtraData(
+func ModifyPayload(
 	p *engineall.ExecutionPayload,
 	executionRequests []prague.ExecutionRequest,
 	extraDataPrefix []byte,
+	gasLimitOverride uint64,
 	parentBeaconBlockRoot common.Hash,
 ) (common.Hash, error) {
 	header, err := buildHeaderFromPayload(p, parentBeaconBlockRoot, executionRequests)
@@ -68,6 +73,11 @@ func ModifyPayloadExtraData(
 				computedHash.Hex(), originalHash.Hex(),
 			)
 		}
+	}
+
+	if gasLimitOverride > 0 {
+		header.GasLimit = gasLimitOverride
+		p.GasLimit = gasLimitOverride
 	}
 
 	// Build new extra data: prefix + "/" separator + original (truncated to

--- a/pkg/payload_builder/service.go
+++ b/pkg/payload_builder/service.go
@@ -69,6 +69,7 @@ type Service struct {
 	scheduledBuildMu  sync.Mutex
 	buildStartedSlots map[phase0.Slot]bool // Slots where building has started (to prevent re-building)
 	skipFiredSlots    map[phase0.Slot]bool // Slots a BuildSkippedEvent was fired for (dedup per slot)
+	attrFallbackArmed map[phase0.Slot]bool // Slots a missing-attributes fallback check is armed for
 
 	// Payload inclusion tracking (deduplication between detection methods)
 	wonPayloadsMu sync.Mutex
@@ -123,6 +124,7 @@ func NewService(
 		log:                    serviceLog,
 		buildStartedSlots:      make(map[phase0.Slot]bool),
 		skipFiredSlots:         make(map[phase0.Slot]bool, 16),
+		attrFallbackArmed:      make(map[phase0.Slot]bool, 16),
 		wonPayloads:            make(map[phase0.Hash32]phase0.Slot, 16),
 	}
 
@@ -408,6 +410,11 @@ func (s *Service) handlePayloadAttributesEvent(event *beacon.PayloadAttributesEv
 		s.markPayloadWon(event.ParentBlockHash, payload.Attributes.ProposalSlot)
 	}
 
+	// Arm the missing-block fallback for the NEXT proposal slot: if its
+	// block goes missing entirely, some clients never emit fresh attributes
+	// and this slot's attributes get re-used instead.
+	s.scheduleAttributesFallback(event.ProposalSlot + 1)
+
 	// Resolve the slot's immutable action plan snapshot once. The plan
 	// service is the scheduling authority: the frozen snapshot carries the
 	// complete build decision (schedule + plan force/suppress + timing).
@@ -472,6 +479,101 @@ func (s *Service) fireBuildSkipped(slot phase0.Slot, build *action_plan.Resolved
 		Slot:   slot,
 		Reason: reason,
 	})
+}
+
+// scheduleAttributesFallback arms a one-shot check for the given proposal
+// slot: some clients do not re-emit payload_attributes when a slot's block is
+// missing entirely, leaving the builder without a build trigger. If no
+// attributes for targetSlot arrived by its build start time, the parent
+// slot's attributes are re-used with the proposal slot advanced (see
+// applyAttributesFallback). Armed once per slot.
+func (s *Service) scheduleAttributesFallback(targetSlot phase0.Slot) {
+	s.scheduledBuildMu.Lock()
+
+	if s.attrFallbackArmed[targetSlot] {
+		s.scheduledBuildMu.Unlock()
+		return
+	}
+
+	s.attrFallbackArmed[targetSlot] = true
+
+	if targetSlot > 64 {
+		cutoff := targetSlot - 64
+		for oldSlot := range s.attrFallbackArmed {
+			if oldSlot < cutoff {
+				delete(s.attrFallbackArmed, oldSlot)
+			}
+		}
+	}
+	s.scheduledBuildMu.Unlock()
+
+	// Fire at the slot's (globally configured) build start time: real
+	// attributes would have arrived long before it, and synthesizing then
+	// leaves the normal scheduling path an immediate build.
+	fireAt := s.chainSvc.SlotToTime(targetSlot).
+		Add(time.Duration(s.cfg.EPBS.BuildStartTime) * time.Millisecond)
+
+	time.AfterFunc(max(time.Until(fireAt), 0), func() {
+		s.applyAttributesFallback(targetSlot)
+	})
+}
+
+// attrFallbackLookback bounds how many slots the missing-block fallback
+// searches backwards for the last received payload attributes (covers runs
+// of consecutive missing blocks).
+const attrFallbackLookback = 8
+
+// applyAttributesFallback re-uses the last available payload attributes for
+// targetSlot when the beacon node never emitted any (missing block): the
+// proposal slot advances and the timestamp moves forward by the number of
+// skipped slots — every other property stays identical, since no new block
+// was built on top. Runs of multiple missing blocks are covered by searching
+// back up to attrFallbackLookback slots. The synthesized event is injected
+// into the event stream (cache + dispatch), so it flows through the exact
+// same build path as a node-received one.
+func (s *Service) applyAttributesFallback(targetSlot phase0.Slot) {
+	if s.clClient == nil || s.ctx == nil || s.ctx.Err() != nil {
+		return
+	}
+
+	events := s.clClient.Events()
+
+	if events.GetLatestPayloadAttributes(targetSlot) != nil {
+		return // real attributes arrived; nothing to do
+	}
+
+	// Find the last slot we actually received (or previously synthesized)
+	// attributes for.
+	var parent *beacon.PayloadAttributesEvent
+
+	for lookback := phase0.Slot(1); lookback <= attrFallbackLookback && lookback <= targetSlot; lookback++ {
+		if parent = events.GetLatestPayloadAttributes(targetSlot - lookback); parent != nil {
+			break
+		}
+	}
+
+	if parent == nil {
+		return
+	}
+
+	skippedSlots := uint64(targetSlot - parent.ProposalSlot)
+
+	synthesized := *parent
+	synthesized.ProposalSlot = targetSlot
+	synthesized.Timestamp = parent.Timestamp +
+		skippedSlots*uint64(s.chainSvc.GetChainSpec().SecondsPerSlot.Seconds())
+
+	if !events.InjectPayloadAttributes(&synthesized) {
+		return // lost the race against a real event
+	}
+
+	s.log.WithFields(logrus.Fields{
+		"slot":          targetSlot,
+		"attrs_from":    parent.ProposalSlot,
+		"missing_slots": skippedSlots,
+		"parent_hash":   fmt.Sprintf("%x", synthesized.ParentBlockHash[:8]),
+	}).Info("No payload attributes received for slot (block missing?), " +
+		"re-using the last available attributes")
 }
 
 // scheduleBuildForSlot schedules payload building for the given slot.

--- a/pkg/rpc/beacon/api.go
+++ b/pkg/rpc/beacon/api.go
@@ -98,19 +98,14 @@ func (c *Client) SubmitExecutionPayloadEnvelope(
 	return nil
 }
 
-// PayloadEnvelopeInfo contains key fields from a fetched execution payload envelope.
-type PayloadEnvelopeInfo struct {
-	BlockRoot    phase0.Root
-	BlockHash    phase0.Hash32
-	BuilderIndex uint64
-}
-
-// GetExecutionPayloadEnvelope fetches the signed execution payload envelope for a block.
-// The blockID can be a block root (hex), slot number, or "head"/"finalized"/"genesis".
+// GetExecutionPayloadEnvelope fetches the signed execution payload envelope
+// for a block as the full fork-agnostic object (consumers reduce it to
+// whatever shape they need). The blockID can be a block root (hex), slot
+// number, or "head"/"finalized"/"genesis".
 func (c *Client) GetExecutionPayloadEnvelope(
 	ctx context.Context,
 	blockID string,
-) (*PayloadEnvelopeInfo, error) {
+) (*eth2all.SignedExecutionPayloadEnvelope, error) {
 	provider, ok := c.client.(eth2client.ExecutionPayloadProvider)
 	if !ok {
 		return nil, fmt.Errorf("client does not support execution payload envelope provider")
@@ -127,13 +122,7 @@ func (c *Client) GetExecutionPayloadEnvelope(
 		return nil, fmt.Errorf("payload envelope response is nil")
 	}
 
-	msg := resp.Data.Message
-
-	return &PayloadEnvelopeInfo{
-		BlockRoot:    msg.BeaconBlockRoot,
-		BlockHash:    msg.Payload.BlockHash,
-		BuilderIndex: uint64(msg.BuilderIndex),
-	}, nil
+	return resp.Data, nil
 }
 
 // SubmitVoluntaryExit submits a signed voluntary exit to the beacon node.
@@ -152,11 +141,8 @@ func (c *Client) SubmitVoluntaryExit(ctx context.Context, exit *phase0.SignedVol
 	return nil
 }
 
-// GetBlockAttestations fetches a beacon block and returns its attestations
-// reduced to the AttestationEvent shape consumed by the head vote tracker.
-// Handles both the Electra+ format (committee_bits + concatenated
-// aggregation_bits) and the pre-Electra format (data.index = committee).
-func (c *Client) GetBlockAttestations(ctx context.Context, blockID string) ([]*AttestationEvent, error) {
+// GetSignedBlock fetches a beacon block as the fork-agnostic signed block.
+func (c *Client) GetSignedBlock(ctx context.Context, blockID string) (*eth2all.SignedBeaconBlock, error) {
 	provider, ok := c.client.(eth2client.SignedBeaconBlockProvider)
 	if !ok {
 		return nil, fmt.Errorf("client does not support signed beacon block provider")
@@ -173,7 +159,19 @@ func (c *Client) GetBlockAttestations(ctx context.Context, blockID string) ([]*A
 		return nil, fmt.Errorf("beacon block response is nil")
 	}
 
-	atts := resp.Data.Message.Body.Attestations
+	return resp.Data, nil
+}
+
+// BlockAttestationEvents reduces a block's attestations to the
+// AttestationEvent shape consumed by the head vote tracker. Handles both the
+// Electra+ format (committee_bits + concatenated aggregation_bits) and the
+// pre-Electra format (data.index = committee).
+func BlockAttestationEvents(block *eth2all.SignedBeaconBlock) []*AttestationEvent {
+	if block == nil || block.Message == nil || block.Message.Body == nil {
+		return nil
+	}
+
+	atts := block.Message.Body.Attestations
 	events := make([]*AttestationEvent, 0, len(atts))
 
 	for _, att := range atts {
@@ -198,5 +196,5 @@ func (c *Client) GetBlockAttestations(ctx context.Context, blockID string) ([]*A
 		events = append(events, event)
 	}
 
-	return events, nil
+	return events
 }

--- a/pkg/rpc/beacon/client.go
+++ b/pkg/rpc/beacon/client.go
@@ -275,6 +275,10 @@ type BlockInfo struct {
 	FinalitySafeExecutionBlockHash phase0.Hash32
 	ParentRoot                     phase0.Root
 	StateRoot                      phase0.Root
+	// Gas limit committed for the block's execution payload: the builder
+	// bid's gas_limit from Gloas on (present even when the payload was
+	// withheld), the embedded payload's gas_limit before.
+	GasLimit uint64
 }
 
 // FinalityInfo contains finality checkpoint execution block hashes.
@@ -324,6 +328,11 @@ func (c *Client) GetBlockInfo(ctx context.Context, blockID string) (*BlockInfo, 
 		return nil, fmt.Errorf("failed to get finality-safe execution block hash: %w", err)
 	}
 
+	gasLimit, err := agnosticExecutionGasLimit(msg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get execution gas limit: %w", err)
+	}
+
 	return &BlockInfo{
 		Slot:                           msg.Slot,
 		Root:                           root,
@@ -331,6 +340,7 @@ func (c *Client) GetBlockInfo(ctx context.Context, blockID string) (*BlockInfo, 
 		FinalitySafeExecutionBlockHash: finalitySafeHash,
 		ParentRoot:                     msg.ParentRoot,
 		StateRoot:                      msg.StateRoot,
+		GasLimit:                       gasLimit,
 	}, nil
 }
 
@@ -378,6 +388,28 @@ func agnosticFinalitySafeExecutionBlockHash(msg *all.BeaconBlock) (phase0.Hash32
 	}
 
 	return body.ExecutionPayload.BlockHash, nil
+}
+
+// agnosticExecutionGasLimit extracts the committed execution gas limit from a
+// fork-agnostic beacon block. From Gloas on it is the builder bid's gas_limit
+// (the value consensus gas-limit checks compare a child bid against, even when
+// the payload was withheld); before Gloas it is the embedded payload's.
+func agnosticExecutionGasLimit(msg *all.BeaconBlock) (uint64, error) {
+	body := msg.Body
+
+	if msg.Version >= version.DataVersionGloas {
+		if body.SignedExecutionPayloadBid == nil || body.SignedExecutionPayloadBid.Message == nil {
+			return 0, fmt.Errorf("no execution payload bid in block")
+		}
+
+		return body.SignedExecutionPayloadBid.Message.GasLimit, nil
+	}
+
+	if body.ExecutionPayload == nil {
+		return 0, fmt.Errorf("no execution payload in block")
+	}
+
+	return body.ExecutionPayload.GasLimit, nil
 }
 
 // GetFinalityInfo fetches finality checkpoints and returns execution block hashes.

--- a/pkg/rpc/beacon/events.go
+++ b/pkg/rpc/beacon/events.go
@@ -304,6 +304,28 @@ func (e *EventStream) GetLatestPayloadAttributes(slot phase0.Slot) *PayloadAttri
 	return e.payloadAttrCache[slot]
 }
 
+// InjectPayloadAttributes caches and dispatches a locally synthesized
+// payload_attributes event exactly like one received from the beacon node
+// (used by the missing-block fallback: some clients do not re-emit attributes
+// when a slot's block is missing entirely). A node-received event for the
+// slot always wins: injection is dropped if one arrived in the meantime.
+// Returns whether the event was injected.
+func (e *EventStream) InjectPayloadAttributes(event *PayloadAttributesEvent) bool {
+	e.payloadAttrCacheMu.Lock()
+
+	if _, exists := e.payloadAttrCache[event.ProposalSlot]; exists {
+		e.payloadAttrCacheMu.Unlock()
+		return false
+	}
+
+	e.payloadAttrCache[event.ProposalSlot] = event
+	e.payloadAttrCacheMu.Unlock()
+
+	e.payloadAttributesDispatcher.Fire(event)
+
+	return true
+}
+
 // CleanupPayloadAttributesCache removes cached payload_attributes entries
 // for slots older than beforeSlot.
 func (e *EventStream) CleanupPayloadAttributesCache(beforeSlot phase0.Slot) {

--- a/pkg/rpc/beacon/events_test.go
+++ b/pkg/rpc/beacon/events_test.go
@@ -137,3 +137,26 @@ func TestParseSingleAttestationEvent_Invalid(t *testing.T) {
 		})
 	}
 }
+
+// TestInjectPayloadAttributes caches and dispatches synthesized attributes,
+// but never overwrites a slot that already has node-received attributes.
+func TestInjectPayloadAttributes(t *testing.T) {
+	stream := NewEventStream(&Client{})
+	sub := stream.SubscribePayloadAttributes()
+	defer sub.Unsubscribe()
+
+	synthesized := &PayloadAttributesEvent{ProposalSlot: 10, ParentBlockNumber: 9}
+	require.True(t, stream.InjectPayloadAttributes(synthesized))
+	assert.Equal(t, synthesized, stream.GetLatestPayloadAttributes(10))
+
+	select {
+	case got := <-sub.Channel():
+		assert.Equal(t, synthesized, got)
+	default:
+		t.Fatal("expected the injected event to be dispatched")
+	}
+
+	// A second injection for the same slot is dropped (the cached event wins).
+	require.False(t, stream.InjectPayloadAttributes(&PayloadAttributesEvent{ProposalSlot: 10}))
+	assert.Equal(t, synthesized, stream.GetLatestPayloadAttributes(10))
+}

--- a/pkg/slot_results/tracker.go
+++ b/pkg/slot_results/tracker.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	eth2all "github.com/ethpandaops/go-eth2-client/spec/all"
 	"github.com/ethpandaops/go-eth2-client/spec/phase0"
 	"github.com/ethpandaops/go-eth2-client/spec/version"
 	"github.com/sirupsen/logrus"
@@ -19,6 +20,7 @@ import (
 	"github.com/ethpandaops/buildoor/pkg/p2p_bidder"
 	"github.com/ethpandaops/buildoor/pkg/payload_bidder"
 	"github.com/ethpandaops/buildoor/pkg/payload_builder"
+	"github.com/ethpandaops/buildoor/pkg/rpc/beacon"
 	"github.com/ethpandaops/buildoor/pkg/utils"
 )
 
@@ -369,16 +371,43 @@ func (t *Tracker) handlePayloadReady(payload *payload_builder.Payload) {
 		blockValue = payload.BlockValue.String()
 	}
 
-	t.upsert(slot, func(result *SlotResult) {
-		result.Build = &BuildOutcome{
-			Status:          BuildStatusReady,
-			BlockHash:       fmt.Sprintf("%#x", payload.BlockHash),
-			BlockValueWei:   blockValue,
-			NumTransactions: numTxs,
-			NumBlobs:        numBlobs,
-			FeeRecipient:    payload.FeeRecipient.Hex(),
-			At:              payload.ReadyAt,
+	outcome := &BuildOutcome{
+		Status:          BuildStatusReady,
+		BlockHash:       fmt.Sprintf("%#x", payload.BlockHash),
+		BlockValueWei:   blockValue,
+		NumTransactions: numTxs,
+		NumBlobs:        numBlobs,
+		FeeRecipient:    payload.FeeRecipient.Hex(),
+		At:              payload.ReadyAt,
+		Attributes:      attributesSnapshot(payload.Attributes),
+	}
+
+	if ep := payload.ExecutionPayload; ep != nil {
+		outcome.BlockNumber = ep.BlockNumber
+		outcome.ParentHash = fmt.Sprintf("%#x", ep.ParentHash)
+		outcome.StateRoot = fmt.Sprintf("%#x", ep.StateRoot)
+		outcome.ReceiptsRoot = fmt.Sprintf("%#x", ep.ReceiptsRoot)
+		outcome.PrevRandao = fmt.Sprintf("%#x", ep.PrevRandao)
+		outcome.Timestamp = ep.Timestamp
+		outcome.GasLimit = ep.GasLimit
+		outcome.GasUsed = ep.GasUsed
+		outcome.ExtraData = fmt.Sprintf("%#x", ep.ExtraData)
+		outcome.BlobGasUsed = ep.BlobGasUsed
+		outcome.ExcessBlobGas = ep.ExcessBlobGas
+		outcome.NumWithdrawals = len(ep.Withdrawals)
+
+		if ep.BaseFeePerGas != nil {
+			outcome.BaseFeePerGas = ep.BaseFeePerGas.Dec()
 		}
+	}
+
+	if reqs := payload.ExecutionRequests; reqs != nil {
+		outcome.NumExecutionRequests = len(reqs.Deposits) + len(reqs.Withdrawals) +
+			len(reqs.Consolidations) + len(reqs.BuilderDeposits) + len(reqs.BuilderExits)
+	}
+
+	t.upsert(slot, func(result *SlotResult) {
+		result.Build = outcome
 	})
 
 	if t.cfg.SlotArtifactCaptureEnabled && payload.ExecutionPayload != nil {
@@ -386,6 +415,46 @@ func (t *Tracker) handlePayloadReady(payload *payload_builder.Payload) {
 			t.log.WithError(err).WithField("slot", slot).Warn("Failed to store payload artifact")
 		}
 	}
+}
+
+// attributesSnapshot reduces a payload_attributes event to the stored
+// snapshot (list fields aggregated to counts).
+func attributesSnapshot(attrs *beacon.PayloadAttributesEvent) *AttributesSnapshot {
+	if attrs == nil {
+		return nil
+	}
+
+	return &AttributesSnapshot{
+		ProposerIndex:         uint64(attrs.ProposerIndex),
+		ParentBlockRoot:       fmt.Sprintf("%#x", attrs.ParentBlockRoot),
+		ParentBlockHash:       fmt.Sprintf("%#x", attrs.ParentBlockHash),
+		ParentBlockNumber:     attrs.ParentBlockNumber,
+		Timestamp:             attrs.Timestamp,
+		PrevRandao:            fmt.Sprintf("%#x", attrs.PrevRandao),
+		SuggestedFeeRecipient: attrs.SuggestedFeeRecipient.Hex(),
+		ParentBeaconBlockRoot: fmt.Sprintf("%#x", attrs.ParentBeaconBlockRoot),
+		TargetGasLimit:        attrs.TargetGasLimit,
+		NumWithdrawals:        len(attrs.Withdrawals),
+		NumInclusionListTxs:   len(attrs.InclusionListTransactions),
+	}
+}
+
+// fillBidDetail copies the bid message properties onto the attempt (blob
+// commitments aggregated to a count).
+func fillBidDetail(attempt *BidAttempt, signedBid *eth2all.SignedExecutionPayloadBid) {
+	if signedBid == nil || signedBid.Message == nil {
+		return
+	}
+
+	bid := signedBid.Message
+	attempt.BlockHash = fmt.Sprintf("%#x", bid.BlockHash)
+	attempt.ParentBlockHash = fmt.Sprintf("%#x", bid.ParentBlockHash)
+	attempt.ParentBlockRoot = fmt.Sprintf("%#x", bid.ParentBlockRoot)
+	attempt.PrevRandao = fmt.Sprintf("%#x", bid.PrevRandao)
+	attempt.FeeRecipient = fmt.Sprintf("%#x", bid.FeeRecipient)
+	attempt.GasLimit = bid.GasLimit
+	attempt.BuilderIndex = uint64(bid.BuilderIndex)
+	attempt.NumBlobCommitments = len(bid.BlobKZGCommitments)
 }
 
 func (t *Tracker) handleBuildStarted(event *payload_builder.PayloadBuildStartedEvent) {
@@ -432,6 +501,8 @@ func (t *Tracker) handleBidSubmission(event *p2p_bidder.BidSubmissionEvent) {
 		Error:              event.Error,
 		At:                 time.Now(),
 	}
+
+	fillBidDetail(&attempt, event.SignedBid)
 
 	switch event.Status {
 	case p2p_bidder.BidStatusSubmitted:
@@ -570,6 +641,12 @@ func (t *Tracker) RecordBuilderAPIBid(slot phase0.Slot, forkName string, signedB
 		ExecutionPaymentGwei: executionPaymentGwei,
 		Error:                errMsg,
 		At:                   time.Now(),
+	}
+
+	// The epbs dialect serves Gloas+ bids with the full message; the legacy
+	// dialect's versioned header bids stay aggregate-only.
+	if signed, ok := signedBid.(*eth2all.SignedExecutionPayloadBid); ok {
+		fillBidDetail(&attempt, signed)
 	}
 
 	marshaler, isMarshaler := signedBid.(sszMarshaler)

--- a/pkg/slot_results/types.go
+++ b/pkg/slot_results/types.go
@@ -100,8 +100,44 @@ type BuildOutcome struct {
 	NumBlobs        int    `json:"num_blobs,omitempty"`
 	FeeRecipient    string `json:"fee_recipient,omitempty"`
 
+	// Full built-payload properties; the list fields (transactions, blobs,
+	// withdrawals, execution requests) are aggregated to counts above/below.
+	BlockNumber          uint64 `json:"block_number,omitempty"`
+	ParentHash           string `json:"parent_hash,omitempty"`
+	StateRoot            string `json:"state_root,omitempty"`
+	ReceiptsRoot         string `json:"receipts_root,omitempty"`
+	PrevRandao           string `json:"prev_randao,omitempty"`
+	Timestamp            uint64 `json:"timestamp,omitempty"`
+	GasLimit             uint64 `json:"gas_limit,omitempty"`
+	GasUsed              uint64 `json:"gas_used,omitempty"`
+	BaseFeePerGas        string `json:"base_fee_per_gas,omitempty"` // wei
+	ExtraData            string `json:"extra_data,omitempty"`       // 0x-hex
+	BlobGasUsed          uint64 `json:"blob_gas_used,omitempty"`
+	ExcessBlobGas        uint64 `json:"excess_blob_gas,omitempty"`
+	NumWithdrawals       int    `json:"num_withdrawals,omitempty"`
+	NumExecutionRequests int    `json:"num_execution_requests,omitempty"`
+
+	// Attributes is the payload_attributes snapshot the build ran on.
+	Attributes *AttributesSnapshot `json:"attributes,omitempty"`
+
 	Error string    `json:"error,omitempty"`
 	At    time.Time `json:"at"`
+}
+
+// AttributesSnapshot captures the payload_attributes a build ran on (list
+// fields aggregated to counts).
+type AttributesSnapshot struct {
+	ProposerIndex         uint64 `json:"proposer_index"`
+	ParentBlockRoot       string `json:"parent_block_root"`
+	ParentBlockHash       string `json:"parent_block_hash"`
+	ParentBlockNumber     uint64 `json:"parent_block_number"`
+	Timestamp             uint64 `json:"timestamp"`
+	PrevRandao            string `json:"prev_randao"`
+	SuggestedFeeRecipient string `json:"suggested_fee_recipient"`
+	ParentBeaconBlockRoot string `json:"parent_beacon_block_root,omitempty"`
+	TargetGasLimit        uint64 `json:"target_gas_limit,omitempty"`
+	NumWithdrawals        int    `json:"num_withdrawals"`
+	NumInclusionListTxs   int    `json:"num_inclusion_list_txs,omitempty"`
 }
 
 // BidAttempt is one bid we constructed, served, submitted — or failed to.
@@ -115,6 +151,18 @@ type BidAttempt struct {
 	// CompetitorHighGwei is the highest known competitor bid at submission
 	// time (p2p only, our own builder index excluded).
 	CompetitorHighGwei *uint64 `json:"competitor_high_gwei,omitempty"`
+
+	// Full bid message properties (Gloas+ bids; blob commitments aggregated
+	// to a count). Empty for legacy Builder API bids and pre-construction
+	// failures.
+	BlockHash          string `json:"block_hash,omitempty"`
+	ParentBlockHash    string `json:"parent_block_hash,omitempty"`
+	ParentBlockRoot    string `json:"parent_block_root,omitempty"`
+	PrevRandao         string `json:"prev_randao,omitempty"`
+	FeeRecipient       string `json:"fee_recipient,omitempty"`
+	GasLimit           uint64 `json:"gas_limit,omitempty"`
+	BuilderIndex       uint64 `json:"builder_index,omitempty"`
+	NumBlobCommitments int    `json:"num_blob_commitments,omitempty"`
 
 	// ArtifactIndex references the slot's stored 'bid' SSZ artifact; nil when
 	// no artifact exists (suppressed, pre-construction failure, or capture

--- a/pkg/webui/handlers/api/events.go
+++ b/pkg/webui/handlers/api/events.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	mathbits "math/bits"
 	"net/http"
 	"sync"
 	"time"
 
+	eth2all "github.com/ethpandaops/go-eth2-client/spec/all"
 	"github.com/ethpandaops/go-eth2-client/spec/phase0"
 
 	"github.com/ethpandaops/buildoor/pkg/action_plan"
@@ -44,6 +46,7 @@ const (
 	EventTypeHeadVotes                   EventType = "head_votes"
 	EventTypeVoteCoverage                EventType = "vote_coverage"
 	EventTypeRevealStarted               EventType = "reveal_started"
+	EventTypeBlockDetail                 EventType = "block_detail"
 	EventTypeBidWon                      EventType = "bid_won"
 	EventTypeBuilderAPIGetHeaderRcvd     EventType = "builder_api_get_header_received"
 	EventTypeBuilderAPIGetHeaderDlvd     EventType = "builder_api_get_header_delivered"
@@ -101,17 +104,19 @@ type PayloadBuildStartedStreamEvent struct {
 // received from the beacon node. It arrives before the slot it targets
 // (ProposalSlot), so the WebUI renders it on the parent slot's graph.
 type PayloadAttributesStreamEvent struct {
-	ProposalSlot       uint64 `json:"proposal_slot"`
-	ProposerIndex      uint64 `json:"proposer_index"`
-	ParentBlockHash    string `json:"parent_block_hash"`
-	ParentBlockRoot    string `json:"parent_block_root"`
-	ParentBlockNumber  uint64 `json:"parent_block_number"`
-	Timestamp          uint64 `json:"timestamp"`
-	FeeRecipient       string `json:"fee_recipient"`
-	TargetGasLimit     uint64 `json:"target_gas_limit"`
-	WithdrawalsCount   int    `json:"withdrawals_count"`
-	ReceivedAt         int64  `json:"received_at"`
-	InclusionListCount int    `json:"inclusion_list_count"`
+	ProposalSlot          uint64 `json:"proposal_slot"`
+	ProposerIndex         uint64 `json:"proposer_index"`
+	ParentBlockHash       string `json:"parent_block_hash"`
+	ParentBlockRoot       string `json:"parent_block_root"`
+	ParentBlockNumber     uint64 `json:"parent_block_number"`
+	Timestamp             uint64 `json:"timestamp"`
+	PrevRandao            string `json:"prev_randao"`
+	FeeRecipient          string `json:"fee_recipient"`
+	ParentBeaconBlockRoot string `json:"parent_beacon_block_root"`
+	TargetGasLimit        uint64 `json:"target_gas_limit"`
+	WithdrawalsCount      int    `json:"withdrawals_count"`
+	ReceivedAt            int64  `json:"received_at"`
+	InclusionListCount    int    `json:"inclusion_list_count"`
 }
 
 // PayloadBuildFailedStreamEvent is sent when a payload build fails, so the WebUI
@@ -129,6 +134,20 @@ type PayloadReadyStreamEvent struct {
 	ParentBlockHash string `json:"parent_block_hash"`
 	BlockValue      string `json:"block_value"`
 	ReadyAt         int64  `json:"ready_at"`
+
+	// Full built-payload properties (list fields aggregated to counts).
+	BlockNumber     uint64 `json:"block_number,omitempty"`
+	FeeRecipient    string `json:"fee_recipient,omitempty"`
+	GasLimit        uint64 `json:"gas_limit,omitempty"`
+	GasUsed         uint64 `json:"gas_used,omitempty"`
+	BaseFeePerGas   string `json:"base_fee_per_gas,omitempty"` // wei
+	ExtraData       string `json:"extra_data,omitempty"`       // 0x-hex
+	BlobGasUsed     uint64 `json:"blob_gas_used,omitempty"`
+	ExcessBlobGas   uint64 `json:"excess_blob_gas,omitempty"`
+	NumTransactions int    `json:"num_transactions"`
+	NumWithdrawals  int    `json:"num_withdrawals"`
+	NumBlobs        int    `json:"num_blobs"`
+	NumExecRequests int    `json:"num_exec_requests"`
 }
 
 // BidSubmittedEvent is sent when we submit a bid (success or failure).
@@ -141,6 +160,15 @@ type BidSubmittedEvent struct {
 	Success   bool   `json:"success"`
 	Error     string `json:"error,omitempty"`
 	Warning   string `json:"warning,omitempty"`
+
+	// Full bid message properties (blob commitments aggregated to a count).
+	ExecutionPayment   uint64 `json:"execution_payment,omitempty"`
+	FeeRecipient       string `json:"fee_recipient,omitempty"`
+	GasLimit           uint64 `json:"gas_limit,omitempty"`
+	BuilderIndex       uint64 `json:"builder_index,omitempty"`
+	ParentBlockHash    string `json:"parent_block_hash,omitempty"`
+	ParentBlockRoot    string `json:"parent_block_root,omitempty"`
+	NumBlobCommitments int    `json:"num_blob_commitments,omitempty"`
 }
 
 // HeadReceivedEvent is sent when a head event is received.
@@ -165,6 +193,7 @@ type RevealStartedStreamEvent struct {
 // UI can render the call's duration; StartedAt is 0 on skips.
 type RevealStreamEvent struct {
 	Slot        uint64 `json:"slot"`
+	Transport   string `json:"transport,omitempty"`
 	Success     bool   `json:"success"`
 	Skipped     bool   `json:"skipped"`
 	SkipReason  string `json:"skip_reason,omitempty"` // plan_disabled | disabled | late | vote_gate_timeout (skips only)
@@ -173,6 +202,10 @@ type RevealStreamEvent struct {
 	MaxAttempts int    `json:"max_attempts,omitempty"`
 	StartedAt   int64  `json:"started_at,omitempty"`
 	Timestamp   int64  `json:"timestamp"`
+
+	// Envelope is the summary of the built (possibly unpublished) envelope;
+	// absent on skips and pre-construction failures.
+	Envelope *EnvelopeDetail `json:"envelope,omitempty"`
 }
 
 // BidStreamEvent represents a bid from any payload_builder.
@@ -183,6 +216,14 @@ type BidStreamEvent struct {
 	BlockHash    string `json:"block_hash"`
 	IsOurs       bool   `json:"is_ours"`
 	ReceivedAt   int64  `json:"received_at"`
+
+	// Full bid message properties (blob commitments aggregated to a count).
+	ExecutionPayment   uint64 `json:"execution_payment,omitempty"`
+	FeeRecipient       string `json:"fee_recipient,omitempty"`
+	GasLimit           uint64 `json:"gas_limit,omitempty"`
+	ParentBlockHash    string `json:"parent_block_hash,omitempty"`
+	ParentBlockRoot    string `json:"parent_block_root,omitempty"`
+	NumBlobCommitments int    `json:"num_blob_commitments,omitempty"`
 }
 
 // SlotStateEvent represents the current state of a slot.
@@ -200,11 +241,59 @@ type SlotStateEvent struct {
 
 // PayloadAvailableStreamEvent is sent when a payload becomes available.
 type PayloadAvailableStreamEvent struct {
-	Slot         uint64 `json:"slot"`
-	BlockRoot    string `json:"block_root"`
-	BlockHash    string `json:"block_hash"`
-	BuilderIndex uint64 `json:"builder_index"`
-	ReceivedAt   int64  `json:"received_at"`
+	Slot       uint64 `json:"slot"`
+	BlockRoot  string `json:"block_root"`
+	ReceivedAt int64  `json:"received_at"`
+
+	EnvelopeDetail
+}
+
+// EnvelopeDetail is the display summary of an execution payload envelope
+// (list fields aggregated to counts). Embedded in the payload_available and
+// reveal stream events.
+type EnvelopeDetail struct {
+	BlockHash       string `json:"block_hash,omitempty"`
+	BuilderIndex    uint64 `json:"builder_index,omitempty"`
+	BlockNumber     uint64 `json:"block_number,omitempty"`
+	GasLimit        uint64 `json:"gas_limit,omitempty"`
+	GasUsed         uint64 `json:"gas_used,omitempty"`
+	BaseFeePerGas   string `json:"base_fee_per_gas,omitempty"` // wei
+	ExtraData       string `json:"extra_data,omitempty"`       // 0x-hex
+	BlobGasUsed     uint64 `json:"blob_gas_used,omitempty"`
+	NumTransactions int    `json:"num_transactions,omitempty"`
+	NumWithdrawals  int    `json:"num_withdrawals,omitempty"`
+	NumExecRequests int    `json:"num_exec_requests,omitempty"`
+}
+
+// fillEnvelopeDetail reduces a signed execution payload envelope to the
+// display summary.
+func fillEnvelopeDetail(detail *EnvelopeDetail, envelope *eth2all.SignedExecutionPayloadEnvelope) {
+	if envelope == nil || envelope.Message == nil {
+		return
+	}
+
+	msg := envelope.Message
+	detail.BuilderIndex = uint64(msg.BuilderIndex)
+
+	if ep := msg.Payload; ep != nil {
+		detail.BlockHash = fmt.Sprintf("%#x", ep.BlockHash)
+		detail.BlockNumber = ep.BlockNumber
+		detail.GasLimit = ep.GasLimit
+		detail.GasUsed = ep.GasUsed
+		detail.ExtraData = fmt.Sprintf("%#x", ep.ExtraData)
+		detail.BlobGasUsed = ep.BlobGasUsed
+		detail.NumTransactions = len(ep.Transactions)
+		detail.NumWithdrawals = len(ep.Withdrawals)
+
+		if ep.BaseFeePerGas != nil {
+			detail.BaseFeePerGas = ep.BaseFeePerGas.Dec()
+		}
+	}
+
+	if reqs := msg.ExecutionRequests; reqs != nil {
+		detail.NumExecRequests = len(reqs.Deposits) + len(reqs.Withdrawals) +
+			len(reqs.Consolidations) + len(reqs.BuilderDeposits) + len(reqs.BuilderExits)
+	}
 }
 
 // BuilderInfoEvent contains builder identity and balance information.
@@ -233,6 +322,54 @@ type HeadVotesStreamEvent struct {
 	ThresholdPct     float64 `json:"threshold_pct"`
 	ThresholdMet     bool    `json:"threshold_met"`
 	Timestamp        int64   `json:"timestamp"`
+}
+
+// BlockDetailStreamEvent is the display summary of an imported beacon block
+// (extracted from the head vote tracker's coverage block fetch; list fields
+// aggregated to counts).
+type BlockDetailStreamEvent struct {
+	Slot          uint64 `json:"slot"`
+	ProposerIndex uint64 `json:"proposer_index"`
+	ParentRoot    string `json:"parent_root"`
+	StateRoot     string `json:"state_root"`
+	Graffiti      string `json:"graffiti"` // 0x-hex
+
+	NumAttestations        int `json:"num_attestations"`
+	NumProposerSlashings   int `json:"num_proposer_slashings,omitempty"`
+	NumAttesterSlashings   int `json:"num_attester_slashings,omitempty"`
+	NumDeposits            int `json:"num_deposits,omitempty"`
+	NumVoluntaryExits      int `json:"num_voluntary_exits,omitempty"`
+	NumBLSChanges          int `json:"num_bls_changes,omitempty"`
+	SyncParticipation      int `json:"sync_participation"`
+	NumBlobCommitments     int `json:"num_blob_commitments,omitempty"`
+	NumPayloadAttestations int `json:"num_payload_attestations,omitempty"`
+
+	// Gloas+: the winning builder bid embedded in the block.
+	Bid *BlockDetailBid `json:"bid,omitempty"`
+	// Pre-Gloas: in-block execution payload summary.
+	Payload *BlockDetailPayload `json:"payload,omitempty"`
+
+	Timestamp int64 `json:"timestamp"`
+}
+
+type BlockDetailBid struct {
+	BuilderIndex     uint64 `json:"builder_index"`
+	ValueGwei        uint64 `json:"value_gwei"`
+	ExecutionPayment uint64 `json:"execution_payment_gwei"`
+	BlockHash        string `json:"block_hash"`
+	ParentBlockHash  string `json:"parent_block_hash"`
+	GasLimit         uint64 `json:"gas_limit"`
+	FeeRecipient     string `json:"fee_recipient"`
+	NumBlobKZGs      int    `json:"num_blob_kzgs,omitempty"`
+}
+
+type BlockDetailPayload struct {
+	BlockNumber     uint64 `json:"block_number"`
+	BlockHash       string `json:"block_hash"`
+	GasLimit        uint64 `json:"gas_limit"`
+	GasUsed         uint64 `json:"gas_used"`
+	NumTransactions int    `json:"num_transactions"`
+	NumWithdrawals  int    `json:"num_withdrawals"`
 }
 
 // VoteCoverageStreamEvent reports how many next-block attesters were seen as
@@ -509,10 +646,16 @@ func (m *EventStreamManager) Start() {
 
 	var coverageChan <-chan *chain.SubnetCoverage
 
+	var blockDetailSub *utils.Subscription[*eth2all.SignedBeaconBlock]
+
+	var blockDetailChan <-chan *eth2all.SignedBeaconBlock
+
 	if m.chainSvc != nil {
 		if tracker := m.chainSvc.GetHeadVoteTracker(); tracker != nil {
 			covSub = tracker.SubscribeCoverage()
 			coverageChan = covSub.Channel()
+			blockDetailSub = tracker.SubscribeBlocks()
+			blockDetailChan = blockDetailSub.Channel()
 			hvSub = tracker.SubscribeUpdates()
 			headVoteChan = hvSub.Channel()
 		}
@@ -552,6 +695,10 @@ func (m *EventStreamManager) Start() {
 
 		if covSub != nil {
 			defer covSub.Unsubscribe()
+		}
+
+		if blockDetailSub != nil {
+			defer blockDetailSub.Unsubscribe()
 		}
 
 		if planChangeSub != nil {
@@ -622,6 +769,14 @@ func (m *EventStreamManager) Start() {
 					Timestamp: time.Now().UnixMilli(),
 					Data:      voteCoverageEvent(event),
 				})
+
+			case event, ok := <-blockDetailChan:
+				if !ok {
+					blockDetailChan = nil
+					continue
+				}
+
+				m.handleBlockDetail(event)
 
 			case event, ok := <-planChangeChan:
 				if !ok {
@@ -855,17 +1010,19 @@ func (m *EventStreamManager) handlePayloadAttributesEvent(event *beacon.PayloadA
 		Type:      EventTypePayloadAttributes,
 		Timestamp: time.Now().UnixMilli(),
 		Data: PayloadAttributesStreamEvent{
-			ProposalSlot:       uint64(event.ProposalSlot),
-			ProposerIndex:      uint64(event.ProposerIndex),
-			ParentBlockHash:    fmt.Sprintf("0x%x", event.ParentBlockHash[:]),
-			ParentBlockRoot:    fmt.Sprintf("0x%x", event.ParentBlockRoot[:]),
-			ParentBlockNumber:  event.ParentBlockNumber,
-			Timestamp:          event.Timestamp,
-			FeeRecipient:       event.SuggestedFeeRecipient.Hex(),
-			TargetGasLimit:     event.TargetGasLimit,
-			InclusionListCount: len(event.InclusionListTransactions),
-			WithdrawalsCount:   len(event.Withdrawals),
-			ReceivedAt:         time.Now().UnixMilli(),
+			ProposalSlot:          uint64(event.ProposalSlot),
+			ProposerIndex:         uint64(event.ProposerIndex),
+			ParentBlockHash:       fmt.Sprintf("0x%x", event.ParentBlockHash[:]),
+			ParentBlockRoot:       fmt.Sprintf("0x%x", event.ParentBlockRoot[:]),
+			ParentBlockNumber:     event.ParentBlockNumber,
+			Timestamp:             event.Timestamp,
+			PrevRandao:            fmt.Sprintf("0x%x", event.PrevRandao[:]),
+			FeeRecipient:          event.SuggestedFeeRecipient.Hex(),
+			ParentBeaconBlockRoot: fmt.Sprintf("0x%x", event.ParentBeaconBlockRoot[:]),
+			TargetGasLimit:        event.TargetGasLimit,
+			InclusionListCount:    len(event.InclusionListTransactions),
+			WithdrawalsCount:      len(event.Withdrawals),
+			ReceivedAt:            time.Now().UnixMilli(),
 		},
 	})
 }
@@ -882,19 +1039,52 @@ func (m *EventStreamManager) handlePayloadBuildFailed(event *payload_builder.Pay
 	})
 }
 
+// payloadReadyStreamEvent assembles the full payload_ready wire event from a
+// built payload (list fields aggregated to counts).
+func payloadReadyStreamEvent(slot phase0.Slot, event *payload_builder.Payload) PayloadReadyStreamEvent {
+	data := PayloadReadyStreamEvent{
+		Slot:            uint64(slot),
+		BlockHash:       fmt.Sprintf("0x%x", event.BlockHash[:]),
+		ParentBlockHash: fmt.Sprintf("0x%x", event.Attributes.ParentBlockHash[:]),
+		BlockValue:      event.BlockValue.String(),
+		ReadyAt:         event.ReadyAt.UnixMilli(),
+		FeeRecipient:    event.FeeRecipient.Hex(),
+	}
+
+	if ep := event.ExecutionPayload; ep != nil {
+		data.BlockNumber = ep.BlockNumber
+		data.GasLimit = ep.GasLimit
+		data.GasUsed = ep.GasUsed
+		data.ExtraData = fmt.Sprintf("0x%x", ep.ExtraData)
+		data.BlobGasUsed = ep.BlobGasUsed
+		data.ExcessBlobGas = ep.ExcessBlobGas
+		data.NumTransactions = len(ep.Transactions)
+		data.NumWithdrawals = len(ep.Withdrawals)
+
+		if ep.BaseFeePerGas != nil {
+			data.BaseFeePerGas = ep.BaseFeePerGas.Dec()
+		}
+	}
+
+	if event.BlobsBundle != nil {
+		data.NumBlobs = len(event.BlobsBundle.Commitments)
+	}
+
+	if reqs := event.ExecutionRequests; reqs != nil {
+		data.NumExecRequests = len(reqs.Deposits) + len(reqs.Withdrawals) +
+			len(reqs.Consolidations) + len(reqs.BuilderDeposits) + len(reqs.BuilderExits)
+	}
+
+	return data
+}
+
 func (m *EventStreamManager) handlePayloadReady(event *payload_builder.Payload) {
 	slot := event.Attributes.ProposalSlot
 
 	m.broadcastForSlot(slot, &StreamEvent{
 		Type:      EventTypePayloadReady,
 		Timestamp: time.Now().UnixMilli(),
-		Data: PayloadReadyStreamEvent{
-			Slot:            uint64(slot),
-			BlockHash:       fmt.Sprintf("0x%x", event.BlockHash[:]),
-			ParentBlockHash: fmt.Sprintf("0x%x", event.Attributes.ParentBlockHash[:]),
-			BlockValue:      event.BlockValue.String(),
-			ReadyAt:         event.ReadyAt.UnixMilli(),
-		},
+		Data:      payloadReadyStreamEvent(slot, event),
 	})
 
 	// Update slot state
@@ -913,19 +1103,32 @@ func (m *EventStreamManager) handlePayloadReady(event *payload_builder.Payload) 
 }
 
 func (m *EventStreamManager) handleBidSubmissionEvent(event *p2p_bidder.BidSubmissionEvent) {
+	data := BidSubmittedEvent{
+		Slot:      uint64(event.Slot),
+		BlockHash: fmt.Sprintf("0x%x", event.BlockHash[:]),
+		Value:     event.Value,
+		BidCount:  event.BidCount,
+		Timestamp: time.Now().UnixMilli(),
+		Success:   event.Success,
+		Error:     event.Error,
+		Warning:   event.Warning,
+	}
+
+	if event.SignedBid != nil && event.SignedBid.Message != nil {
+		bid := event.SignedBid.Message
+		data.ExecutionPayment = uint64(bid.ExecutionPayment)
+		data.FeeRecipient = fmt.Sprintf("0x%x", bid.FeeRecipient)
+		data.GasLimit = bid.GasLimit
+		data.BuilderIndex = uint64(bid.BuilderIndex)
+		data.ParentBlockHash = fmt.Sprintf("0x%x", bid.ParentBlockHash[:])
+		data.ParentBlockRoot = fmt.Sprintf("0x%x", bid.ParentBlockRoot[:])
+		data.NumBlobCommitments = len(bid.BlobKZGCommitments)
+	}
+
 	m.broadcastForSlot(event.Slot, &StreamEvent{
 		Type:      EventTypeBidSubmitted,
 		Timestamp: time.Now().UnixMilli(),
-		Data: BidSubmittedEvent{
-			Slot:      uint64(event.Slot),
-			BlockHash: fmt.Sprintf("0x%x", event.BlockHash[:]),
-			Value:     event.Value,
-			BidCount:  event.BidCount,
-			Timestamp: time.Now().UnixMilli(),
-			Success:   event.Success,
-			Error:     event.Error,
-			Warning:   event.Warning,
-		},
+		Data:      data,
 	})
 
 	// Update slot state only on success
@@ -978,12 +1181,18 @@ func (m *EventStreamManager) handleBidEvent(event *beacon.BidEvent) {
 		Type:      EventTypeBidEvent,
 		Timestamp: time.Now().UnixMilli(),
 		Data: BidStreamEvent{
-			Slot:         uint64(event.Slot),
-			BuilderIndex: event.BuilderIndex,
-			Value:        event.Value,
-			BlockHash:    fmt.Sprintf("0x%x", event.BlockHash[:]),
-			IsOurs:       isOurs,
-			ReceivedAt:   event.ReceivedAt.UnixMilli(),
+			Slot:               uint64(event.Slot),
+			BuilderIndex:       event.BuilderIndex,
+			Value:              event.Value,
+			BlockHash:          fmt.Sprintf("0x%x", event.BlockHash[:]),
+			IsOurs:             isOurs,
+			ReceivedAt:         event.ReceivedAt.UnixMilli(),
+			ExecutionPayment:   event.ExecutionPayment,
+			FeeRecipient:       fmt.Sprintf("0x%x", event.FeeRecipient[:]),
+			GasLimit:           event.GasLimit,
+			ParentBlockHash:    fmt.Sprintf("0x%x", event.ParentBlockHash[:]),
+			ParentBlockRoot:    fmt.Sprintf("0x%x", event.ParentBlockRoot[:]),
+			NumBlobCommitments: len(event.BlobKZGCommitments),
 		},
 	})
 
@@ -1027,14 +1236,79 @@ func (m *EventStreamManager) handlePayloadAvailableEvent(event *beacon.PayloadAv
 
 	envelope, err := m.builderSvc.GetCLClient().GetExecutionPayloadEnvelope(ctx, blockRootHex)
 	if err == nil {
-		streamEvent.BlockHash = fmt.Sprintf("0x%x", envelope.BlockHash[:])
-		streamEvent.BuilderIndex = envelope.BuilderIndex
+		fillEnvelopeDetail(&streamEvent.EnvelopeDetail, envelope)
 	}
 
 	m.broadcastForSlot(event.Slot, &StreamEvent{
 		Type:      EventTypePayloadAvailable,
 		Timestamp: time.Now().UnixMilli(),
 		Data:      streamEvent,
+	})
+}
+
+// handleBlockDetail reduces an imported block (full fork-agnostic signed
+// block from the head vote tracker's fetch) to the display summary and
+// broadcasts it (list fields aggregated to counts).
+func (m *EventStreamManager) handleBlockDetail(block *eth2all.SignedBeaconBlock) {
+	if block == nil || block.Message == nil || block.Message.Body == nil {
+		return
+	}
+
+	msg := block.Message
+	body := msg.Body
+
+	data := BlockDetailStreamEvent{
+		Slot:                   uint64(msg.Slot),
+		ProposerIndex:          uint64(msg.ProposerIndex),
+		ParentRoot:             fmt.Sprintf("%#x", msg.ParentRoot),
+		StateRoot:              fmt.Sprintf("%#x", msg.StateRoot),
+		Graffiti:               fmt.Sprintf("%#x", body.Graffiti),
+		NumAttestations:        len(body.Attestations),
+		NumProposerSlashings:   len(body.ProposerSlashings),
+		NumAttesterSlashings:   len(body.AttesterSlashings),
+		NumDeposits:            len(body.Deposits),
+		NumVoluntaryExits:      len(body.VoluntaryExits),
+		NumBLSChanges:          len(body.BLSToExecutionChanges),
+		NumBlobCommitments:     len(body.BlobKZGCommitments),
+		NumPayloadAttestations: len(body.PayloadAttestations),
+		Timestamp:              time.Now().UnixMilli(),
+	}
+
+	if body.SyncAggregate != nil {
+		for _, b := range body.SyncAggregate.SyncCommitteeBits {
+			data.SyncParticipation += mathbits.OnesCount8(b)
+		}
+	}
+
+	if signedBid := body.SignedExecutionPayloadBid; signedBid != nil && signedBid.Message != nil {
+		bid := signedBid.Message
+		data.Bid = &BlockDetailBid{
+			BuilderIndex:     uint64(bid.BuilderIndex),
+			ValueGwei:        uint64(bid.Value),
+			ExecutionPayment: uint64(bid.ExecutionPayment),
+			BlockHash:        fmt.Sprintf("%#x", bid.BlockHash),
+			ParentBlockHash:  fmt.Sprintf("%#x", bid.ParentBlockHash),
+			GasLimit:         bid.GasLimit,
+			FeeRecipient:     fmt.Sprintf("%#x", bid.FeeRecipient),
+			NumBlobKZGs:      len(bid.BlobKZGCommitments),
+		}
+	}
+
+	if ep := body.ExecutionPayload; ep != nil {
+		data.Payload = &BlockDetailPayload{
+			BlockNumber:     ep.BlockNumber,
+			BlockHash:       fmt.Sprintf("%#x", ep.BlockHash),
+			GasLimit:        ep.GasLimit,
+			GasUsed:         ep.GasUsed,
+			NumTransactions: len(ep.Transactions),
+			NumWithdrawals:  len(ep.Withdrawals),
+		}
+	}
+
+	m.broadcastForSlot(msg.Slot, &StreamEvent{
+		Type:      EventTypeBlockDetail,
+		Timestamp: time.Now().UnixMilli(),
+		Data:      data,
 	})
 }
 
@@ -1562,20 +1836,28 @@ func (m *EventStreamManager) BroadcastReveal(event *payload_bidder.RevealResult)
 		startedAt = event.StartedAt.UnixMilli()
 	}
 
+	data := RevealStreamEvent{
+		Slot:        slot,
+		Transport:   string(event.Transport),
+		Success:     event.Success,
+		Skipped:     event.Skipped,
+		SkipReason:  event.SkipReason,
+		Error:       event.Error,
+		Attempt:     event.Attempt,
+		MaxAttempts: event.MaxAttempts,
+		StartedAt:   startedAt,
+		Timestamp:   completedAt,
+	}
+
+	if event.Envelope != nil {
+		data.Envelope = &EnvelopeDetail{}
+		fillEnvelopeDetail(data.Envelope, event.Envelope)
+	}
+
 	m.broadcastForSlot(event.Slot, &StreamEvent{
 		Type:      EventTypeReveal,
 		Timestamp: time.Now().UnixMilli(),
-		Data: RevealStreamEvent{
-			Slot:        slot,
-			Success:     event.Success,
-			Skipped:     event.Skipped,
-			SkipReason:  event.SkipReason,
-			Error:       event.Error,
-			Attempt:     event.Attempt,
-			MaxAttempts: event.MaxAttempts,
-			StartedAt:   startedAt,
-			Timestamp:   completedAt,
-		},
+		Data:      data,
 	})
 
 	// Update slot state

--- a/pkg/webui/handlers/docs/docs.go
+++ b/pkg/webui/handlers/docs/docs.go
@@ -2626,7 +2626,11 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "skip_reason": {
-                    "description": "plan_disabled | late",
+                    "description": "plan_disabled | disabled | late | vote_gate_timeout",
+                    "type": "string"
+                },
+                "started_at": {
+                    "description": "StartedAt is when the attempt began (envelope construction + submit\ncall); nil on skips where nothing was attempted.",
                     "type": "string"
                 },
                 "status": {

--- a/pkg/webui/handlers/docs/docs.go
+++ b/pkg/webui/handlers/docs/docs.go
@@ -2438,6 +2438,44 @@ const docTemplate = `{
                 }
             }
         },
+        "slot_results.AttributesSnapshot": {
+            "type": "object",
+            "properties": {
+                "num_inclusion_list_txs": {
+                    "type": "integer"
+                },
+                "num_withdrawals": {
+                    "type": "integer"
+                },
+                "parent_beacon_block_root": {
+                    "type": "string"
+                },
+                "parent_block_hash": {
+                    "type": "string"
+                },
+                "parent_block_number": {
+                    "type": "integer"
+                },
+                "parent_block_root": {
+                    "type": "string"
+                },
+                "prev_randao": {
+                    "type": "string"
+                },
+                "proposer_index": {
+                    "type": "integer"
+                },
+                "suggested_fee_recipient": {
+                    "type": "string"
+                },
+                "target_gas_limit": {
+                    "type": "integer"
+                },
+                "timestamp": {
+                    "type": "integer"
+                }
+            }
+        },
         "slot_results.BidAttempt": {
             "type": "object",
             "properties": {
@@ -2448,6 +2486,13 @@ const docTemplate = `{
                 "at": {
                     "type": "string"
                 },
+                "block_hash": {
+                    "description": "Full bid message properties (Gloas+ bids; blob commitments aggregated\nto a count). Empty for legacy Builder API bids and pre-construction\nfailures.",
+                    "type": "string"
+                },
+                "builder_index": {
+                    "type": "integer"
+                },
                 "competitor_high_gwei": {
                     "description": "CompetitorHighGwei is the highest known competitor bid at submission\ntime (p2p only, our own builder index excluded).",
                     "type": "integer"
@@ -2457,6 +2502,24 @@ const docTemplate = `{
                 },
                 "execution_payment_gwei": {
                     "type": "integer"
+                },
+                "fee_recipient": {
+                    "type": "string"
+                },
+                "gas_limit": {
+                    "type": "integer"
+                },
+                "num_blob_commitments": {
+                    "type": "integer"
+                },
+                "parent_block_hash": {
+                    "type": "string"
+                },
+                "parent_block_root": {
+                    "type": "string"
+                },
+                "prev_randao": {
+                    "type": "string"
                 },
                 "status": {
                     "$ref": "#/definitions/slot_results.BidStatus"
@@ -2513,8 +2576,27 @@ const docTemplate = `{
                 "at": {
                     "type": "string"
                 },
+                "attributes": {
+                    "description": "Attributes is the payload_attributes snapshot the build ran on.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/slot_results.AttributesSnapshot"
+                        }
+                    ]
+                },
+                "base_fee_per_gas": {
+                    "description": "wei",
+                    "type": "string"
+                },
+                "blob_gas_used": {
+                    "type": "integer"
+                },
                 "block_hash": {
                     "type": "string"
+                },
+                "block_number": {
+                    "description": "Full built-payload properties; the list fields (transactions, blobs,\nwithdrawals, execution requests) are aggregated to counts above/below.",
+                    "type": "integer"
                 },
                 "block_value_wei": {
                     "type": "string"
@@ -2522,21 +2604,55 @@ const docTemplate = `{
                 "error": {
                     "type": "string"
                 },
+                "excess_blob_gas": {
+                    "type": "integer"
+                },
+                "extra_data": {
+                    "description": "0x-hex",
+                    "type": "string"
+                },
                 "fee_recipient": {
                     "type": "string"
                 },
+                "gas_limit": {
+                    "type": "integer"
+                },
+                "gas_used": {
+                    "type": "integer"
+                },
                 "num_blobs": {
+                    "type": "integer"
+                },
+                "num_execution_requests": {
                     "type": "integer"
                 },
                 "num_transactions": {
                     "type": "integer"
                 },
+                "num_withdrawals": {
+                    "type": "integer"
+                },
+                "parent_hash": {
+                    "type": "string"
+                },
+                "prev_randao": {
+                    "type": "string"
+                },
+                "receipts_root": {
+                    "type": "string"
+                },
                 "skip_reason": {
                     "description": "action_plan.BuildSkipReason* when skipped",
                     "type": "string"
                 },
+                "state_root": {
+                    "type": "string"
+                },
                 "status": {
                     "$ref": "#/definitions/slot_results.BuildStatus"
+                },
+                "timestamp": {
+                    "type": "integer"
                 }
             }
         },

--- a/pkg/webui/handlers/docs/swagger.json
+++ b/pkg/webui/handlers/docs/swagger.json
@@ -2615,7 +2615,11 @@
                     "type": "string"
                 },
                 "skip_reason": {
-                    "description": "plan_disabled | late",
+                    "description": "plan_disabled | disabled | late | vote_gate_timeout",
+                    "type": "string"
+                },
+                "started_at": {
+                    "description": "StartedAt is when the attempt began (envelope construction + submit\ncall); nil on skips where nothing was attempted.",
                     "type": "string"
                 },
                 "status": {

--- a/pkg/webui/handlers/docs/swagger.json
+++ b/pkg/webui/handlers/docs/swagger.json
@@ -2427,6 +2427,44 @@
                 }
             }
         },
+        "slot_results.AttributesSnapshot": {
+            "type": "object",
+            "properties": {
+                "num_inclusion_list_txs": {
+                    "type": "integer"
+                },
+                "num_withdrawals": {
+                    "type": "integer"
+                },
+                "parent_beacon_block_root": {
+                    "type": "string"
+                },
+                "parent_block_hash": {
+                    "type": "string"
+                },
+                "parent_block_number": {
+                    "type": "integer"
+                },
+                "parent_block_root": {
+                    "type": "string"
+                },
+                "prev_randao": {
+                    "type": "string"
+                },
+                "proposer_index": {
+                    "type": "integer"
+                },
+                "suggested_fee_recipient": {
+                    "type": "string"
+                },
+                "target_gas_limit": {
+                    "type": "integer"
+                },
+                "timestamp": {
+                    "type": "integer"
+                }
+            }
+        },
         "slot_results.BidAttempt": {
             "type": "object",
             "properties": {
@@ -2437,6 +2475,13 @@
                 "at": {
                     "type": "string"
                 },
+                "block_hash": {
+                    "description": "Full bid message properties (Gloas+ bids; blob commitments aggregated\nto a count). Empty for legacy Builder API bids and pre-construction\nfailures.",
+                    "type": "string"
+                },
+                "builder_index": {
+                    "type": "integer"
+                },
                 "competitor_high_gwei": {
                     "description": "CompetitorHighGwei is the highest known competitor bid at submission\ntime (p2p only, our own builder index excluded).",
                     "type": "integer"
@@ -2446,6 +2491,24 @@
                 },
                 "execution_payment_gwei": {
                     "type": "integer"
+                },
+                "fee_recipient": {
+                    "type": "string"
+                },
+                "gas_limit": {
+                    "type": "integer"
+                },
+                "num_blob_commitments": {
+                    "type": "integer"
+                },
+                "parent_block_hash": {
+                    "type": "string"
+                },
+                "parent_block_root": {
+                    "type": "string"
+                },
+                "prev_randao": {
+                    "type": "string"
                 },
                 "status": {
                     "$ref": "#/definitions/slot_results.BidStatus"
@@ -2502,8 +2565,27 @@
                 "at": {
                     "type": "string"
                 },
+                "attributes": {
+                    "description": "Attributes is the payload_attributes snapshot the build ran on.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/slot_results.AttributesSnapshot"
+                        }
+                    ]
+                },
+                "base_fee_per_gas": {
+                    "description": "wei",
+                    "type": "string"
+                },
+                "blob_gas_used": {
+                    "type": "integer"
+                },
                 "block_hash": {
                     "type": "string"
+                },
+                "block_number": {
+                    "description": "Full built-payload properties; the list fields (transactions, blobs,\nwithdrawals, execution requests) are aggregated to counts above/below.",
+                    "type": "integer"
                 },
                 "block_value_wei": {
                     "type": "string"
@@ -2511,21 +2593,55 @@
                 "error": {
                     "type": "string"
                 },
+                "excess_blob_gas": {
+                    "type": "integer"
+                },
+                "extra_data": {
+                    "description": "0x-hex",
+                    "type": "string"
+                },
                 "fee_recipient": {
                     "type": "string"
                 },
+                "gas_limit": {
+                    "type": "integer"
+                },
+                "gas_used": {
+                    "type": "integer"
+                },
                 "num_blobs": {
+                    "type": "integer"
+                },
+                "num_execution_requests": {
                     "type": "integer"
                 },
                 "num_transactions": {
                     "type": "integer"
                 },
+                "num_withdrawals": {
+                    "type": "integer"
+                },
+                "parent_hash": {
+                    "type": "string"
+                },
+                "prev_randao": {
+                    "type": "string"
+                },
+                "receipts_root": {
+                    "type": "string"
+                },
                 "skip_reason": {
                     "description": "action_plan.BuildSkipReason* when skipped",
                     "type": "string"
                 },
+                "state_root": {
+                    "type": "string"
+                },
                 "status": {
                     "$ref": "#/definitions/slot_results.BuildStatus"
+                },
+                "timestamp": {
+                    "type": "integer"
                 }
             }
         },

--- a/pkg/webui/handlers/docs/swagger.yaml
+++ b/pkg/webui/handlers/docs/swagger.yaml
@@ -771,6 +771,31 @@ definitions:
       value_wei:
         type: string
     type: object
+  slot_results.AttributesSnapshot:
+    properties:
+      num_inclusion_list_txs:
+        type: integer
+      num_withdrawals:
+        type: integer
+      parent_beacon_block_root:
+        type: string
+      parent_block_hash:
+        type: string
+      parent_block_number:
+        type: integer
+      parent_block_root:
+        type: string
+      prev_randao:
+        type: string
+      proposer_index:
+        type: integer
+      suggested_fee_recipient:
+        type: string
+      target_gas_limit:
+        type: integer
+      timestamp:
+        type: integer
+    type: object
   slot_results.BidAttempt:
     properties:
       artifact_index:
@@ -781,6 +806,14 @@ definitions:
         type: integer
       at:
         type: string
+      block_hash:
+        description: |-
+          Full bid message properties (Gloas+ bids; blob commitments aggregated
+          to a count). Empty for legacy Builder API bids and pre-construction
+          failures.
+        type: string
+      builder_index:
+        type: integer
       competitor_high_gwei:
         description: |-
           CompetitorHighGwei is the highest known competitor bid at submission
@@ -790,6 +823,18 @@ definitions:
         type: string
       execution_payment_gwei:
         type: integer
+      fee_recipient:
+        type: string
+      gas_limit:
+        type: integer
+      num_blob_commitments:
+        type: integer
+      parent_block_hash:
+        type: string
+      parent_block_root:
+        type: string
+      prev_randao:
+        type: string
       status:
         $ref: '#/definitions/slot_results.BidStatus'
       total_value_gwei:
@@ -830,23 +875,60 @@ definitions:
     properties:
       at:
         type: string
+      attributes:
+        allOf:
+        - $ref: '#/definitions/slot_results.AttributesSnapshot'
+        description: Attributes is the payload_attributes snapshot the build ran on.
+      base_fee_per_gas:
+        description: wei
+        type: string
+      blob_gas_used:
+        type: integer
       block_hash:
         type: string
+      block_number:
+        description: |-
+          Full built-payload properties; the list fields (transactions, blobs,
+          withdrawals, execution requests) are aggregated to counts above/below.
+        type: integer
       block_value_wei:
         type: string
       error:
         type: string
+      excess_blob_gas:
+        type: integer
+      extra_data:
+        description: 0x-hex
+        type: string
       fee_recipient:
         type: string
+      gas_limit:
+        type: integer
+      gas_used:
+        type: integer
       num_blobs:
+        type: integer
+      num_execution_requests:
         type: integer
       num_transactions:
         type: integer
+      num_withdrawals:
+        type: integer
+      parent_hash:
+        type: string
+      prev_randao:
+        type: string
+      receipts_root:
+        type: string
       skip_reason:
         description: action_plan.BuildSkipReason* when skipped
         type: string
+      state_root:
+        type: string
       status:
         $ref: '#/definitions/slot_results.BuildStatus'
+      timestamp:
+        type: integer
     type: object
   slot_results.BuildStatus:
     enum:

--- a/pkg/webui/handlers/docs/swagger.yaml
+++ b/pkg/webui/handlers/docs/swagger.yaml
@@ -915,7 +915,12 @@ definitions:
       error:
         type: string
       skip_reason:
-        description: plan_disabled | late
+        description: plan_disabled | disabled | late | vote_gate_timeout
+        type: string
+      started_at:
+        description: |-
+          StartedAt is when the attempt began (envelope construction + submit
+          call); nil on skips where nothing was attempted.
         type: string
       status:
         $ref: '#/definitions/slot_results.RevealStatus'

--- a/pkg/webui/src/components/BidArtifactLinks.tsx
+++ b/pkg/webui/src/components/BidArtifactLinks.tsx
@@ -1,0 +1,73 @@
+import React, { useEffect, useState } from 'react';
+import type { SlotBidArtifactsResponse } from '../types';
+import { downloadSSZ } from './Popover';
+
+interface BidArtifactLinksProps {
+  slot: number;
+  transport: string; // "p2p" | "builder-api"
+  valueGwei: number;
+  timeMs: number; // event timestamp (unix ms) to disambiguate equal values
+}
+
+// BidArtifactLinks resolves the stored SSZ artifact behind a bid dot: the
+// graph state (SSE-driven) does not know artifact indices, so the slot's bid
+// artifact listing is fetched on popover open and matched by transport +
+// value + nearest timestamp.
+export const BidArtifactLinks: React.FC<BidArtifactLinksProps> = ({ slot, transport, valueGwei, timeMs }) => {
+  const [state, setState] = useState<'loading' | 'none' | 'error'>('loading');
+  const [index, setIndex] = useState<number | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    fetch(`/api/buildoor/slot-results/${slot}/bids`)
+      .then(async res => {
+        if (res.status === 404) throw new Error('none');
+        if (!res.ok) throw new Error(`request failed (${res.status})`);
+        return res.json() as Promise<SlotBidArtifactsResponse>;
+      })
+      .then(data => {
+        if (cancelled) return;
+        const candidates = (data.bids || []).filter(
+          b => (b.transport ?? '') === transport && (b.total_value_gwei ?? -1) === valueGwei
+        );
+        if (candidates.length === 0) {
+          setState('none');
+          return;
+        }
+        // Closest stored-at timestamp wins when several bids share the value.
+        candidates.sort((a, b) =>
+          Math.abs((a.at ?? 0) - timeMs) - Math.abs((b.at ?? 0) - timeMs));
+        setIndex(candidates[0].index);
+        setState('none'); // state unused once index is set
+      })
+      .catch(() => { if (!cancelled) setState('error'); });
+
+    return () => { cancelled = true; };
+  }, [slot, transport, valueGwei, timeMs]);
+
+  if (index === null) {
+    return state === 'loading'
+      ? <div className="popover-artifacts text-muted small">resolving artifact…</div>
+      : null;
+  }
+
+  const url = `/api/buildoor/slot-results/${slot}/bids/${index}`;
+  return (
+    <div className="popover-artifacts d-flex gap-1">
+      <a href={url} target="_blank" rel="noreferrer" className="btn btn-outline-secondary ap-artifact-btn">
+        JSON
+      </a>
+      <button
+        type="button"
+        className="btn btn-outline-secondary ap-artifact-btn"
+        onClick={() => {
+          downloadSSZ(url, `slot-${slot}-bid-${index}.ssz`)
+            .catch((err) => console.error('artifact download failed:', err));
+        }}
+      >
+        SSZ
+      </button>
+    </div>
+  );
+};

--- a/pkg/webui/src/components/Popover.tsx
+++ b/pkg/webui/src/components/Popover.tsx
@@ -9,6 +9,27 @@ export interface PopoverItem {
 export interface PopoverData {
   title: string;
   items: PopoverItem[];
+  // Use the wide popover variant (long values like extra data / content
+  // summaries would otherwise line-break).
+  wide?: boolean;
+  // Recorded artifact behind this event: renders JSON/SSZ download buttons.
+  artifact?: { url: string; filename: string };
+}
+
+// downloadSSZ fetches an artifact with SSZ content negotiation and triggers a
+// browser download.
+export async function downloadSSZ(url: string, filename: string): Promise<void> {
+  const res = await fetch(url, { headers: { Accept: 'application/octet-stream' } });
+  if (!res.ok) {
+    throw new Error(`artifact download failed (${res.status})`);
+  }
+  const blob = await res.blob();
+  const objectUrl = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = objectUrl;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(objectUrl);
 }
 
 interface PopoverProps {
@@ -54,7 +75,7 @@ export const Popover: React.FC<PopoverProps> = ({ data, x, y, onClose, children 
   return (
     <div
       ref={popoverRef}
-      className={`event-popover ${children ? 'event-popover-wide' : ''}`}
+      className={`event-popover ${data.wide ? 'event-popover-wide' : ''}`}
       style={{ left: x, top: y }}
       onClick={(e) => e.stopPropagation()}
     >
@@ -84,6 +105,28 @@ export const Popover: React.FC<PopoverProps> = ({ data, x, y, onClose, children 
           ))}
         </tbody>
       </table>
+      {data.artifact && (
+        <div className="popover-artifacts d-flex gap-1">
+          <a
+            href={data.artifact.url}
+            target="_blank"
+            rel="noreferrer"
+            className="btn btn-outline-secondary ap-artifact-btn"
+          >
+            JSON
+          </a>
+          <button
+            type="button"
+            className="btn btn-outline-secondary ap-artifact-btn"
+            onClick={() => {
+              downloadSSZ(data.artifact!.url, data.artifact!.filename)
+                .catch((err) => console.error('artifact download failed:', err));
+            }}
+          >
+            SSZ
+          </button>
+        </div>
+      )}
       {children}
     </div>
   );

--- a/pkg/webui/src/components/SlotGraph.tsx
+++ b/pkg/webui/src/components/SlotGraph.tsx
@@ -3,6 +3,7 @@ import type { SlotState, Config, ChainInfo, OurBid, ExternalBid, HeadVoteDataPoi
 import { formatGwei, isSlotScheduled, calculateSlotTiming, calculatePosition } from '../utils';
 import { Popover, PopoverData } from './Popover';
 import { HeadVoteHeatmap } from './HeadVoteHeatmap';
+import { BidArtifactLinks } from './BidArtifactLinks';
 import { CurrentTimeIndicator } from './CurrentTimeIndicator';
 import { BuildDelayLine } from './BuildDelayLine';
 
@@ -27,7 +28,24 @@ interface PopoverState {
   y: number;
   // Set for the head-votes popover: embeds the per-name arrival heatmap.
   headVoteSlot?: number;
+  // Set for bid popovers: resolves the bid's stored SSZ artifact on open.
+  bidArtifact?: { transport: string; valueGwei: number; timeMs: number };
 }
+
+// decodeExtraData renders a payload's 0x-hex extra data as printable ASCII
+// when possible (builders commonly stamp readable tags), else keeps the hex.
+const decodeExtraData = (hex: string): string => {
+  const raw = hex.startsWith('0x') ? hex.slice(2) : hex;
+  if (raw.length === 0) return '(empty)';
+
+  let text = '';
+  for (let i = 0; i + 1 < raw.length || i < raw.length; i += 2) {
+    const code = parseInt(raw.slice(i, i + 2), 16);
+    if (Number.isNaN(code) || code < 0x20 || code > 0x7e) return hex;
+    text += String.fromCharCode(code);
+  }
+  return text;
+};
 
 // Maps participation percentage (0-100) to SVG Y coordinate (100=bottom, 0=top).
 const pctToY = (pct: number): number => {
@@ -230,14 +248,16 @@ export const SlotGraph: React.FC<SlotGraphProps> = ({
     slotLabel += ' (next)';
   }
 
-  const showPopover = useCallback((e: React.MouseEvent, data: PopoverData) => {
+  const showPopover = useCallback((e: React.MouseEvent, data: PopoverData,
+    extra?: Omit<PopoverState, 'data' | 'x' | 'y'>) => {
     e.stopPropagation();
     const rect = (e.target as HTMLElement).getBoundingClientRect();
+    const width = data.wide ? 460 : 320;
     let x = rect.left;
-    if (x + 320 > window.innerWidth) {
-      x = window.innerWidth - 330;
+    if (x + width > window.innerWidth) {
+      x = window.innerWidth - width - 10;
     }
-    setPopover({ data, x, y: rect.bottom + 5 });
+    setPopover({ data, x, y: rect.bottom + 5, ...extra });
   }, []);
 
   const closePopover = useCallback(() => {
@@ -294,7 +314,8 @@ export const SlotGraph: React.FC<SlotGraphProps> = ({
     className: string,
     timeMs: number,
     data: PopoverData,
-    key: string
+    key: string,
+    extra?: Omit<PopoverState, 'data' | 'x' | 'y'>
   ) => {
     const x = calculatePosition(timeMs, rangeStart, totalRange);
     if (x > 100) return null;
@@ -307,7 +328,7 @@ export const SlotGraph: React.FC<SlotGraphProps> = ({
         key={key}
         className={`event-dot ${className}`}
         style={{ left: `${clampedX}%` }}
-        onClick={(e) => showPopover(e, data)}
+        onClick={(e) => showPopover(e, data, extra)}
       />
     );
   };
@@ -483,6 +504,7 @@ export const SlotGraph: React.FC<SlotGraphProps> = ({
                     setPopover({
                       data: {
                         title: 'Head Vote Participation',
+                        wide: true,
                         items: popoverItems
                       },
                       x: Math.min(e.clientX, window.innerWidth - 470),
@@ -573,8 +595,23 @@ export const SlotGraph: React.FC<SlotGraphProps> = ({
                   copyValue: attr.parentBlockRoot
                 },
                 { label: 'Parent Block #', value: `${attr.parentBlockNumber}` },
+                ...(attr.parentBeaconBlockRoot ? [{
+                  label: 'Beacon Parent Root',
+                  value: truncateHash(attr.parentBeaconBlockRoot),
+                  copyValue: attr.parentBeaconBlockRoot
+                }] : []),
+                ...(attr.prevRandao ? [{
+                  label: 'Prev Randao',
+                  value: truncateHash(attr.prevRandao),
+                  copyValue: attr.prevRandao
+                }] : []),
+                { label: 'Timestamp', value: `${attr.timestamp}` },
                 { label: 'Gas Limit', value: `${attr.targetGasLimit}` },
                 { label: 'Withdrawals', value: `${attr.withdrawalsCount}` },
+                ...(attr.inclusionListCount !== undefined ? [{
+                  label: 'Inclusion List',
+                  value: `${attr.inclusionListCount} txs`
+                }] : []),
                 {
                   label: 'Fee Recipient',
                   value: truncateHash(attr.feeRecipient),
@@ -591,6 +628,11 @@ export const SlotGraph: React.FC<SlotGraphProps> = ({
             state.payloadCreatedAt - slotStartTime,
             {
               title: 'Payload Created',
+              wide: true,
+              artifact: {
+                url: `/api/buildoor/slot-results/${slot}/payload`,
+                filename: `slot-${slot}-payload.ssz`
+              },
               items: [
                 { label: 'Time', value: `${state.payloadCreatedAt - slotStartTime}ms` },
                 ...(state.payloadBlockHash ? [{
@@ -601,6 +643,37 @@ export const SlotGraph: React.FC<SlotGraphProps> = ({
                 ...(state.payloadBlockValue ? [{
                   label: 'Block Value',
                   value: formatGwei(state.payloadBlockValue)
+                }] : []),
+                ...(state.payloadDetail?.blockNumber !== undefined ? [{
+                  label: 'Block #',
+                  value: `${state.payloadDetail.blockNumber}`
+                }] : []),
+                ...(state.payloadDetail?.feeRecipient ? [{
+                  label: 'Fee Recipient',
+                  value: truncateHash(state.payloadDetail.feeRecipient),
+                  copyValue: state.payloadDetail.feeRecipient
+                }] : []),
+                ...(state.payloadDetail?.gasUsed !== undefined ? [{
+                  label: 'Gas',
+                  value: `${state.payloadDetail.gasUsed.toLocaleString()} / ${(state.payloadDetail.gasLimit ?? 0).toLocaleString()}`
+                }] : []),
+                ...(state.payloadDetail?.baseFeePerGas ? [{
+                  label: 'Base Fee',
+                  value: `${state.payloadDetail.baseFeePerGas} wei`
+                }] : []),
+                ...(state.payloadDetail?.extraData ? [{
+                  label: 'Extra Data',
+                  value: decodeExtraData(state.payloadDetail.extraData),
+                  copyValue: state.payloadDetail.extraData
+                }] : []),
+                ...(state.payloadDetail?.blobGasUsed !== undefined && state.payloadDetail.blobGasUsed > 0 ? [{
+                  label: 'Blob Gas',
+                  value: `${state.payloadDetail.blobGasUsed.toLocaleString()} (excess ${(state.payloadDetail.excessBlobGas ?? 0).toLocaleString()})`
+                }] : []),
+                ...(state.payloadDetail ? [{
+                  label: 'Contents',
+                  value: `${state.payloadDetail.numTransactions ?? 0} txs, ${state.payloadDetail.numBlobs ?? 0} blobs, ` +
+                    `${state.payloadDetail.numWithdrawals ?? 0} wdrls, ${state.payloadDetail.numExecRequests ?? 0} reqs`
                 }] : [])
               ]
             },
@@ -614,8 +687,10 @@ export const SlotGraph: React.FC<SlotGraphProps> = ({
             if (x > 100) return null;
             const clampedX = Math.max(0, x);
             const won = !!state.bidWon;
+            const detail = state.blockDetail;
             const popoverData: PopoverData = {
               title: won ? 'Block Won!' : 'Block Received',
+              wide: !!detail,
               items: [
                 { label: 'Time', value: `${blockMs}ms` },
                 ...(state.blockRoot ? [{
@@ -623,6 +698,61 @@ export const SlotGraph: React.FC<SlotGraphProps> = ({
                   value: truncateHash(state.blockRoot),
                   copyValue: state.blockRoot
                 }] : []),
+                ...(detail ? [
+                  { label: 'Proposer', value: `${detail.proposer_index}` },
+                  {
+                    label: 'Parent Root',
+                    value: truncateHash(detail.parent_root),
+                    copyValue: detail.parent_root
+                  },
+                  {
+                    label: 'State Root',
+                    value: truncateHash(detail.state_root),
+                    copyValue: detail.state_root
+                  },
+                  { label: 'Graffiti', value: decodeExtraData(detail.graffiti) },
+                  { label: 'Attestations', value: `${detail.num_attestations}` },
+                  { label: 'Sync Participation', value: `${detail.sync_participation}` },
+                  ...(detail.num_payload_attestations ? [{
+                    label: 'PTC Votes',
+                    value: `${detail.num_payload_attestations}`
+                  }] : []),
+                  ...(detail.num_blob_commitments ? [{
+                    label: 'Blobs',
+                    value: `${detail.num_blob_commitments} commitments`
+                  }] : []),
+                  ...((detail.num_proposer_slashings || detail.num_attester_slashings ||
+                       detail.num_deposits || detail.num_voluntary_exits || detail.num_bls_changes) ? [{
+                    label: 'Operations',
+                    value: `${detail.num_proposer_slashings ?? 0} psl, ${detail.num_attester_slashings ?? 0} asl, ` +
+                      `${detail.num_deposits ?? 0} dep, ${detail.num_voluntary_exits ?? 0} exits, ` +
+                      `${detail.num_bls_changes ?? 0} blsc`
+                  }] : []),
+                  ...(detail.bid ? [
+                    {
+                      label: 'Winning Bid',
+                      value: `builder ${detail.bid.builder_index}, ${formatGwei(detail.bid.value_gwei)}` +
+                        (detail.bid.execution_payment_gwei ? ` (+${formatGwei(detail.bid.execution_payment_gwei)} exec)` : '')
+                    },
+                    {
+                      label: 'Bid Block Hash',
+                      value: truncateHash(detail.bid.block_hash),
+                      copyValue: detail.bid.block_hash
+                    },
+                    { label: 'Bid Gas Limit', value: detail.bid.gas_limit.toLocaleString() }
+                  ] : []),
+                  ...(detail.payload ? [
+                    {
+                      label: 'Payload',
+                      value: `block ${detail.payload.block_number}, ${detail.payload.num_transactions} txs, ` +
+                        `${detail.payload.num_withdrawals} wdrls`
+                    },
+                    {
+                      label: 'Payload Gas',
+                      value: `${detail.payload.gas_used.toLocaleString()} / ${detail.payload.gas_limit.toLocaleString()}`
+                    }
+                  ] : [])
+                ] : []),
                 ...(won ? [{ label: 'Result', value: 'Our payload was included in this block' }] : [])
               ]
             };
@@ -644,6 +774,13 @@ export const SlotGraph: React.FC<SlotGraphProps> = ({
             state.payloadAvailableAt - slotStartTime,
             {
               title: 'Payload Available',
+              wide: !!state.payloadAvailableDetail,
+              ...(state.bidWon ? {
+                artifact: {
+                  url: `/api/buildoor/slot-results/${slot}/envelope`,
+                  filename: `slot-${slot}-envelope.ssz`
+                }
+              } : {}),
               items: [
                 { label: 'Time', value: `${state.payloadAvailableAt - slotStartTime}ms` },
                 ...(state.payloadAvailableBlockHash ? [{
@@ -654,6 +791,30 @@ export const SlotGraph: React.FC<SlotGraphProps> = ({
                 ...(state.payloadAvailableBuilder !== undefined ? [{
                   label: 'Builder Index',
                   value: String(state.payloadAvailableBuilder)
+                }] : []),
+                ...(state.payloadAvailableDetail?.block_number !== undefined ? [{
+                  label: 'Block #',
+                  value: `${state.payloadAvailableDetail.block_number}`
+                }] : []),
+                ...(state.payloadAvailableDetail?.gas_used !== undefined ? [{
+                  label: 'Gas',
+                  value: `${state.payloadAvailableDetail.gas_used.toLocaleString()} / ` +
+                    `${(state.payloadAvailableDetail.gas_limit ?? 0).toLocaleString()}`
+                }] : []),
+                ...(state.payloadAvailableDetail?.base_fee_per_gas ? [{
+                  label: 'Base Fee',
+                  value: `${state.payloadAvailableDetail.base_fee_per_gas} wei`
+                }] : []),
+                ...(state.payloadAvailableDetail?.extra_data ? [{
+                  label: 'Extra Data',
+                  value: decodeExtraData(state.payloadAvailableDetail.extra_data),
+                  copyValue: state.payloadAvailableDetail.extra_data
+                }] : []),
+                ...(state.payloadAvailableDetail ? [{
+                  label: 'Contents',
+                  value: `${state.payloadAvailableDetail.num_transactions ?? 0} txs, ` +
+                    `${state.payloadAvailableDetail.num_withdrawals ?? 0} wdrls, ` +
+                    `${state.payloadAvailableDetail.num_exec_requests ?? 0} reqs`
                 }] : [])
               ]
             },
@@ -671,11 +832,38 @@ export const SlotGraph: React.FC<SlotGraphProps> = ({
                 items: [
                   { label: 'Time', value: `${bidMs}ms` },
                   { label: 'Bid Amount', value: formatGwei(bid.value) },
+                  ...(bid.executionPayment !== undefined ? [{
+                    label: 'Exec Payment',
+                    value: formatGwei(bid.executionPayment)
+                  }] : []),
                   { label: 'Builder Index', value: String(bid.builder) },
                   ...(bid.blockHash ? [{
                     label: 'Block Hash',
                     value: truncateHash(bid.blockHash),
                     copyValue: bid.blockHash
+                  }] : []),
+                  ...(bid.parentBlockHash ? [{
+                    label: 'Parent Hash',
+                    value: truncateHash(bid.parentBlockHash),
+                    copyValue: bid.parentBlockHash
+                  }] : []),
+                  ...(bid.parentBlockRoot ? [{
+                    label: 'Parent Root',
+                    value: truncateHash(bid.parentBlockRoot),
+                    copyValue: bid.parentBlockRoot
+                  }] : []),
+                  ...(bid.feeRecipient ? [{
+                    label: 'Fee Recipient',
+                    value: truncateHash(bid.feeRecipient),
+                    copyValue: bid.feeRecipient
+                  }] : []),
+                  ...(bid.gasLimit !== undefined && bid.gasLimit > 0 ? [{
+                    label: 'Gas Limit',
+                    value: bid.gasLimit.toLocaleString()
+                  }] : []),
+                  ...(bid.numBlobCommitments !== undefined && bid.numBlobCommitments > 0 ? [{
+                    label: 'Blobs',
+                    value: `${bid.numBlobCommitments} commitments`
                   }] : [])
                 ]
               },
@@ -699,16 +887,44 @@ export const SlotGraph: React.FC<SlotGraphProps> = ({
                   items: [
                     { label: 'Time', value: `${bidMs}ms` },
                     { label: 'Bid Amount', value: formatGwei(bid.value) },
+                    ...(bid.executionPayment !== undefined ? [{
+                      label: 'Exec Payment',
+                      value: formatGwei(bid.executionPayment)
+                    }] : []),
                     ...(bid.blockHash ? [{
                       label: 'Block Hash',
                       value: truncateHash(bid.blockHash),
                       copyValue: bid.blockHash
                     }] : []),
+                    ...(bid.parentBlockHash ? [{
+                      label: 'Parent Hash',
+                      value: truncateHash(bid.parentBlockHash),
+                      copyValue: bid.parentBlockHash
+                    }] : []),
+                    ...(bid.parentBlockRoot ? [{
+                      label: 'Parent Root',
+                      value: truncateHash(bid.parentBlockRoot),
+                      copyValue: bid.parentBlockRoot
+                    }] : []),
+                    ...(bid.feeRecipient ? [{
+                      label: 'Fee Recipient',
+                      value: truncateHash(bid.feeRecipient),
+                      copyValue: bid.feeRecipient
+                    }] : []),
+                    ...(bid.gasLimit !== undefined && bid.gasLimit > 0 ? [{
+                      label: 'Gas Limit',
+                      value: bid.gasLimit.toLocaleString()
+                    }] : []),
+                    ...(bid.numBlobCommitments !== undefined && bid.numBlobCommitments > 0 ? [{
+                      label: 'Blobs',
+                      value: `${bid.numBlobCommitments} commitments`
+                    }] : []),
                     { label: 'Status', value: bidSuccess ? 'Success' : 'Failed' },
                     ...(bid.error ? [{ label: 'Error', value: bid.error }] : [])
                   ]
                 },
-                `bid-${idx}`
+                `bid-${idx}`,
+                { bidArtifact: { transport: 'p2p', valueGwei: bid.value, timeMs: bid.time } }
               );
             })}
 
@@ -769,7 +985,15 @@ export const SlotGraph: React.FC<SlotGraphProps> = ({
                     att.time - slotStartTime,
                     {
                       title,
+                      wide: !!att.envelope,
+                      ...(!att.skipped ? {
+                        artifact: {
+                          url: `/api/buildoor/slot-results/${slot}/envelope`,
+                          filename: `slot-${slot}-envelope.ssz`
+                        }
+                      } : {}),
                       items: [
+                        ...(att.transport ? [{ label: 'Transport', value: att.transport }] : []),
                         ...(att.startedAt !== undefined
                           ? [{ label: 'Started', value: `${att.startedAt - slotStartTime}ms` }]
                           : []),
@@ -777,7 +1001,21 @@ export const SlotGraph: React.FC<SlotGraphProps> = ({
                         ...(durationMs !== undefined ? [{ label: 'Duration', value: `${durationMs}ms` }] : []),
                         { label: 'Status', value: status },
                         ...(att.skipped && att.skipReason ? [{ label: 'Reason', value: att.skipReason }] : []),
-                        ...(att.error ? [{ label: 'Error', value: att.error }] : [])
+                        ...(att.error ? [{ label: 'Error', value: att.error }] : []),
+                        ...(att.envelope?.block_hash ? [{
+                          label: 'Payload Hash',
+                          value: truncateHash(att.envelope.block_hash),
+                          copyValue: att.envelope.block_hash
+                        }] : []),
+                        ...(att.envelope?.gas_used !== undefined ? [{
+                          label: 'Gas',
+                          value: `${att.envelope.gas_used.toLocaleString()} / ${(att.envelope.gas_limit ?? 0).toLocaleString()}`
+                        }] : []),
+                        ...(att.envelope ? [{
+                          label: 'Contents',
+                          value: `${att.envelope.num_transactions ?? 0} txs, ${att.envelope.num_withdrawals ?? 0} wdrls, ` +
+                            `${att.envelope.num_exec_requests ?? 0} reqs`
+                        }] : [])
                       ]
                     },
                     `reveal-dot-${idx}`
@@ -902,6 +1140,14 @@ export const SlotGraph: React.FC<SlotGraphProps> = ({
         <Popover data={popover.data} x={popover.x} y={popover.y} onClose={closePopover}>
           {popover.headVoteSlot !== undefined && (
             <HeadVoteHeatmap slot={popover.headVoteSlot} slotDurationMs={slotDuration} />
+          )}
+          {popover.bidArtifact && (
+            <BidArtifactLinks
+              slot={slot}
+              transport={popover.bidArtifact.transport}
+              valueGwei={popover.bidArtifact.valueGwei}
+              timeMs={popover.bidArtifact.timeMs}
+            />
           )}
         </Popover>
       )}

--- a/pkg/webui/src/components/actionplan/SlotEditModal.tsx
+++ b/pkg/webui/src/components/actionplan/SlotEditModal.tsx
@@ -627,10 +627,57 @@ const ResultView: React.FC<{
                 </div>
               )}
               <KV label="Value">{weiToEth(build.block_value_wei)}</KV>
-              <KV label="Txs / Blobs">
-                {build.num_transactions ?? 0} / {build.num_blobs ?? 0}
+              <KV label="Contents">
+                {build.num_transactions ?? 0} txs, {build.num_blobs ?? 0} blobs,{' '}
+                {build.num_withdrawals ?? 0} wdrls, {build.num_execution_requests ?? 0} reqs
               </KV>
+              {build.block_number !== undefined && <KV label="Block #">{build.block_number}</KV>}
+              {build.gas_used !== undefined && (
+                <KV label="Gas">
+                  {build.gas_used.toLocaleString()} / {(build.gas_limit ?? 0).toLocaleString()}
+                </KV>
+              )}
+              {build.base_fee_per_gas && <KV label="Base Fee">{build.base_fee_per_gas} wei</KV>}
+              {build.blob_gas_used !== undefined && build.blob_gas_used > 0 && (
+                <KV label="Blob Gas">
+                  {build.blob_gas_used.toLocaleString()} (excess {(build.excess_blob_gas ?? 0).toLocaleString()})
+                </KV>
+              )}
+              {build.timestamp !== undefined && <KV label="Timestamp">{build.timestamp}</KV>}
+              {build.extra_data && <KV label="Extra Data">{build.extra_data}</KV>}
               <KV label="At">{formatDateTime(build.at)}</KV>
+              {build.parent_hash && (
+                <div className="col-12">
+                  <div className="config-item">
+                    <div className="config-item-label">Parent Hash</div>
+                    <div className="config-item-value font-monospace ap-break">{build.parent_hash}</div>
+                  </div>
+                </div>
+              )}
+              {build.state_root && (
+                <div className="col-12">
+                  <div className="config-item">
+                    <div className="config-item-label">State Root</div>
+                    <div className="config-item-value font-monospace ap-break">{build.state_root}</div>
+                  </div>
+                </div>
+              )}
+              {build.receipts_root && (
+                <div className="col-12">
+                  <div className="config-item">
+                    <div className="config-item-label">Receipts Root</div>
+                    <div className="config-item-value font-monospace ap-break">{build.receipts_root}</div>
+                  </div>
+                </div>
+              )}
+              {build.prev_randao && (
+                <div className="col-12">
+                  <div className="config-item">
+                    <div className="config-item-label">Prev Randao</div>
+                    <div className="config-item-value font-monospace ap-break">{build.prev_randao}</div>
+                  </div>
+                </div>
+              )}
               {build.fee_recipient && (
                 <div className="col-12">
                   <div className="config-item">
@@ -640,6 +687,55 @@ const ResultView: React.FC<{
                 </div>
               )}
             </div>
+            {build.attributes && (
+              <>
+                <div className="section-header mt-3 mb-1">Payload Attributes</div>
+                <div className="row g-2">
+                  <KV label="Proposer">{build.attributes.proposer_index}</KV>
+                  <KV label="Parent Block #">{build.attributes.parent_block_number}</KV>
+                  <KV label="Timestamp">{build.attributes.timestamp}</KV>
+                  {build.attributes.target_gas_limit !== undefined && build.attributes.target_gas_limit > 0 && (
+                    <KV label="Target Gas Limit">{build.attributes.target_gas_limit.toLocaleString()}</KV>
+                  )}
+                  <KV label="Contents">
+                    {build.attributes.num_withdrawals} wdrls
+                    {build.attributes.num_inclusion_list_txs ? `, ${build.attributes.num_inclusion_list_txs} IL txs` : ''}
+                  </KV>
+                  <div className="col-12">
+                    <div className="config-item">
+                      <div className="config-item-label">Parent Hash</div>
+                      <div className="config-item-value font-monospace ap-break">{build.attributes.parent_block_hash}</div>
+                    </div>
+                  </div>
+                  <div className="col-12">
+                    <div className="config-item">
+                      <div className="config-item-label">Parent Root</div>
+                      <div className="config-item-value font-monospace ap-break">{build.attributes.parent_block_root}</div>
+                    </div>
+                  </div>
+                  {build.attributes.parent_beacon_block_root && (
+                    <div className="col-12">
+                      <div className="config-item">
+                        <div className="config-item-label">Beacon Parent Root</div>
+                        <div className="config-item-value font-monospace ap-break">{build.attributes.parent_beacon_block_root}</div>
+                      </div>
+                    </div>
+                  )}
+                  <div className="col-12">
+                    <div className="config-item">
+                      <div className="config-item-label">Prev Randao</div>
+                      <div className="config-item-value font-monospace ap-break">{build.attributes.prev_randao}</div>
+                    </div>
+                  </div>
+                  <div className="col-12">
+                    <div className="config-item">
+                      <div className="config-item-label">Suggested Fee Recipient</div>
+                      <div className="config-item-value font-monospace ap-break">{build.attributes.suggested_fee_recipient}</div>
+                    </div>
+                  </div>
+                </div>
+              </>
+            )}
           </div>
         </div>
       )}
@@ -664,13 +760,25 @@ const ResultView: React.FC<{
                   <th className="text-end">Value</th>
                   <th className="text-end">Exec Payment</th>
                   <th className="text-end">Competitor High</th>
+                  <th>Block Hash</th>
+                  <th className="text-end">Gas Limit</th>
+                  <th className="text-end">Blobs</th>
                   <th>Artifact</th>
                   <th className="text-end">At</th>
                 </tr>
               </thead>
               <tbody>
                 {result.bids!.map((bid, i) => (
-                  <tr key={i}>
+                  <tr
+                    key={i}
+                    title={[
+                      bid.parent_block_hash ? `parent hash: ${bid.parent_block_hash}` : '',
+                      bid.parent_block_root ? `parent root: ${bid.parent_block_root}` : '',
+                      bid.prev_randao ? `prev randao: ${bid.prev_randao}` : '',
+                      bid.fee_recipient ? `fee recipient: ${bid.fee_recipient}` : '',
+                      bid.builder_index !== undefined ? `builder index: ${bid.builder_index}` : ''
+                    ].filter(Boolean).join('\n')}
+                  >
                     <td>{i + 1}</td>
                     <td>
                       <StatusBadge map={BID_BADGES} status={bid.status} />
@@ -689,6 +797,15 @@ const ResultView: React.FC<{
                       {bid.competitor_high_gwei !== undefined
                         ? bid.competitor_high_gwei.toLocaleString()
                         : '—'}
+                    </td>
+                    <td className="font-monospace">
+                      {bid.block_hash ? `${bid.block_hash.slice(0, 10)}…` : '—'}
+                    </td>
+                    <td className="text-end font-monospace">
+                      {bid.gas_limit !== undefined && bid.gas_limit > 0 ? bid.gas_limit.toLocaleString() : '—'}
+                    </td>
+                    <td className="text-end font-monospace">
+                      {bid.num_blob_commitments ?? 0}
                     </td>
                     <td>
                       {bid.artifact_index !== undefined ? (
@@ -764,6 +881,7 @@ const ResultView: React.FC<{
                   <th>Status</th>
                   <th>Transport</th>
                   <th>Detail</th>
+                  <th className="text-end">Started</th>
                   <th className="text-end">At</th>
                 </tr>
               </thead>
@@ -778,6 +896,9 @@ const ResultView: React.FC<{
                     <td className="small">
                       {attempt.skip_reason && <span className="text-muted">{attempt.skip_reason}</span>}
                       {attempt.error && <span className="text-danger"> {attempt.error}</span>}
+                    </td>
+                    <td className="text-end text-muted">
+                      {attempt.started_at ? formatDateTime(attempt.started_at) : '—'}
                     </td>
                     <td className="text-end text-muted">{formatDateTime(attempt.at)}</td>
                   </tr>

--- a/pkg/webui/src/hooks/refreshIntervals.ts
+++ b/pkg/webui/src/hooks/refreshIntervals.ts
@@ -1,0 +1,10 @@
+// Shared REST background-refresh intervals. SSE is the live update channel —
+// REST polling only guards against slow drift (e.g. registration counts), so
+// it runs slow and aligned across hooks instead of each picking its own
+// cadence.
+//
+// SLOW: near-static data (status cards, builder preferences). LIVE: data that
+// genuinely changes slot-by-slot (proposer preferences page); only polled
+// while its page is open.
+export const REFRESH_INTERVAL_SLOW_MS = 60_000;
+export const REFRESH_INTERVAL_LIVE_MS = 12_000;

--- a/pkg/webui/src/hooks/useBuilderAPIStatus.ts
+++ b/pkg/webui/src/hooks/useBuilderAPIStatus.ts
@@ -1,8 +1,12 @@
 import { useEffect, useRef, useState } from 'react';
 import type { BuilderAPIStatus } from '../types';
 import { useAuth } from './useAuth';
+import { REFRESH_INTERVAL_SLOW_MS } from './refreshIntervals';
 
-export function useBuilderAPIStatus() {
+// refreshKey: optional dependency that triggers an immediate refetch when it
+// changes (e.g. the SSE-delivered builder_api_enabled flag) — live changes
+// come through SSE, so the background poll can stay slow.
+export function useBuilderAPIStatus(refreshKey?: unknown) {
   const [status, setStatus] = useState<BuilderAPIStatus | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -39,10 +43,11 @@ export function useBuilderAPIStatus() {
     };
 
     fetchStatus();
-    // Refresh every 10 seconds
-    const interval = setInterval(fetchStatus, 10000);
+    // Slow background refresh only — live changes arrive via SSE and the
+    // refreshKey dependency.
+    const interval = setInterval(fetchStatus, REFRESH_INTERVAL_SLOW_MS);
     return () => clearInterval(interval);
-  }, [getAuthHeader]);
+  }, [getAuthHeader, refreshKey]);
 
   return { status, loading, error };
 }

--- a/pkg/webui/src/hooks/useBuilderPreferences.ts
+++ b/pkg/webui/src/hooks/useBuilderPreferences.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { REFRESH_INTERVAL_SLOW_MS } from './refreshIntervals';
 import type { BuilderPreference, BuilderPreferencesResponse } from '../types';
 
 export function useBuilderPreferences() {
@@ -39,8 +40,8 @@ export function useBuilderPreferences() {
 
   useEffect(() => {
     fetchPreferences();
-    // Poll every 12 seconds (one slot) — proposers submit preferences ahead of their slot
-    const interval = setInterval(fetchPreferences, 12000);
+    // Builder preferences change rarely; slow aligned background refresh.
+    const interval = setInterval(fetchPreferences, REFRESH_INTERVAL_SLOW_MS);
     return () => clearInterval(interval);
   }, []);
 

--- a/pkg/webui/src/hooks/useEventStream.ts
+++ b/pkg/webui/src/hooks/useEventStream.ts
@@ -246,9 +246,12 @@ export function useEventStream(): UseEventStreamResult {
             parent_block_root: string;
             parent_block_number: number;
             timestamp: number;
+            prev_randao?: string;
             fee_recipient: string;
+            parent_beacon_block_root?: string;
             target_gas_limit: number;
             withdrawals_count: number;
+            inclusion_list_count?: number;
             received_at: number;
           };
           addEvent('payload_attributes', `Payload attributes received for slot ${data.proposal_slot}`, event.timestamp);
@@ -265,9 +268,12 @@ export function useEventStream(): UseEventStreamResult {
               parentBlockRoot: data.parent_block_root,
               parentBlockNumber: data.parent_block_number,
               timestamp: data.timestamp,
+              prevRandao: data.prev_randao,
               feeRecipient: data.fee_recipient,
+              parentBeaconBlockRoot: data.parent_beacon_block_root,
               targetGasLimit: data.target_gas_limit,
               withdrawalsCount: data.withdrawals_count,
+              inclusionListCount: data.inclusion_list_count,
               receivedAt: data.received_at
             };
             setSlotStates(prev => {
@@ -302,19 +308,43 @@ export function useEventStream(): UseEventStreamResult {
         case 'payload_ready': {
           // block_value is the EL's MEV value as a wei decimal string; convert to
           // gwei so it matches the gwei-based formatGwei display used elsewhere.
-          const data = event.data as { slot: number; block_hash: string; block_value: string; ready_at: number };
+          const data = event.data as {
+            slot: number; block_hash: string; block_value: string; ready_at: number;
+            block_number?: number; fee_recipient?: string; gas_limit?: number; gas_used?: number;
+            base_fee_per_gas?: string; extra_data?: string; blob_gas_used?: number; excess_blob_gas?: number;
+            num_transactions?: number; num_withdrawals?: number; num_blobs?: number; num_exec_requests?: number;
+          };
           addEvent('payload_ready', `Payload ready for slot ${data.slot} (hash: ${data.block_hash})`, event.timestamp);
           updateSlotState(data.slot, {
             payloadReady: true,
             payloadCreatedAt: data.ready_at,
             payloadBlockHash: data.block_hash,
-            payloadBlockValue: data.block_value ? Number(data.block_value) / 1e9 : 0
+            payloadBlockValue: data.block_value ? Number(data.block_value) / 1e9 : 0,
+            payloadDetail: {
+              blockNumber: data.block_number,
+              feeRecipient: data.fee_recipient,
+              gasLimit: data.gas_limit,
+              gasUsed: data.gas_used,
+              baseFeePerGas: data.base_fee_per_gas,
+              extraData: data.extra_data,
+              blobGasUsed: data.blob_gas_used,
+              excessBlobGas: data.excess_blob_gas,
+              numTransactions: data.num_transactions,
+              numWithdrawals: data.num_withdrawals,
+              numBlobs: data.num_blobs,
+              numExecRequests: data.num_exec_requests
+            }
           });
           break;
         }
 
         case 'bid_submitted': {
-          const data = event.data as { slot: number; block_hash: string; value: number; bid_count: number; success: boolean; error?: string; warning?: string };
+          const data = event.data as {
+            slot: number; block_hash: string; value: number; bid_count: number; success: boolean;
+            error?: string; warning?: string; execution_payment?: number; fee_recipient?: string;
+            gas_limit?: number; builder_index?: number; parent_block_hash?: string;
+            parent_block_root?: string; num_blob_commitments?: number;
+          };
           const bidSuccess = data.success !== false;
           // A warning without an error on an unsuccessful event is a skip
           // (e.g. no proposer preferences cached for the slot), not a failed
@@ -346,7 +376,14 @@ export function useEventStream(): UseEventStreamResult {
               blockHash: data.block_hash,
               count: data.bid_count,
               success: bidSuccess,
-              error: data.error
+              error: data.error,
+              executionPayment: data.execution_payment,
+              feeRecipient: data.fee_recipient,
+              gasLimit: data.gas_limit,
+              builderIndex: data.builder_index,
+              parentBlockHash: data.parent_block_hash,
+              parentBlockRoot: data.parent_block_root,
+              numBlobCommitments: data.num_blob_commitments
             });
             return {
               ...prev,
@@ -365,6 +402,12 @@ export function useEventStream(): UseEventStreamResult {
           break;
         }
 
+        case 'block_detail': {
+          const data = event.data as import('../types').BlockDetail;
+          updateSlotState(data.slot, { blockDetail: data });
+          break;
+        }
+
         case 'reveal_started': {
           const data = event.data as { slot: number; attempt: number; started_at: number };
           updateSlotState(data.slot, {
@@ -374,7 +417,11 @@ export function useEventStream(): UseEventStreamResult {
         }
 
         case 'reveal': {
-          const data = event.data as { slot: number; success: boolean; skipped: boolean; skip_reason?: string; error?: string; attempt?: number; max_attempts?: number; started_at?: number; timestamp?: number };
+          const data = event.data as {
+            slot: number; success: boolean; skipped: boolean; skip_reason?: string; error?: string;
+            attempt?: number; max_attempts?: number; started_at?: number; timestamp?: number;
+            transport?: string; envelope?: import('../types').EnvelopeDetail;
+          };
           const failed = !data.success && !data.skipped;
           const attempt = data.attempt || 0;
           const maxAttempts = data.max_attempts || 0;
@@ -390,6 +437,8 @@ export function useEventStream(): UseEventStreamResult {
             revealAttempts.push({
               time: data.timestamp ?? event.timestamp,
               startedAt: data.started_at || undefined,
+              transport: data.transport,
+              envelope: data.envelope,
               success: data.success,
               skipped: data.skipped,
               skipReason: data.skip_reason,
@@ -415,7 +464,11 @@ export function useEventStream(): UseEventStreamResult {
         }
 
         case 'bid_event': {
-          const data = event.data as { slot: number; builder_index: number; value: number; block_hash: string; is_ours: boolean; received_at: number };
+          const data = event.data as {
+            slot: number; builder_index: number; value: number; block_hash: string; is_ours: boolean;
+            received_at: number; execution_payment?: number; fee_recipient?: string; gas_limit?: number;
+            parent_block_hash?: string; parent_block_root?: string; num_blob_commitments?: number;
+          };
           if (data.is_ours) {
             addEvent('bid_event', `Our bid seen on network for slot ${data.slot}`, event.timestamp);
           } else {
@@ -426,7 +479,13 @@ export function useEventStream(): UseEventStreamResult {
                 time: data.received_at,
                 value: data.value,
                 builder: data.builder_index,
-                blockHash: data.block_hash
+                blockHash: data.block_hash,
+                executionPayment: data.execution_payment,
+                feeRecipient: data.fee_recipient,
+                gasLimit: data.gas_limit,
+                parentBlockHash: data.parent_block_hash,
+                parentBlockRoot: data.parent_block_root,
+                numBlobCommitments: data.num_blob_commitments
               });
               return { ...prev, [data.slot]: { ...state, externalBids } };
             });
@@ -435,9 +494,12 @@ export function useEventStream(): UseEventStreamResult {
         }
 
         case 'payload_available': {
-          const data = event.data as { slot: number; block_hash: string; builder_index: number; received_at: number };
+          const data = event.data as {
+            slot: number; block_hash: string; builder_index: number; received_at: number;
+          } & import('../types').EnvelopeDetail;
           addEvent('payload_available', `Payload available for slot ${data.slot}`, event.timestamp);
           updateSlotState(data.slot, {
+            payloadAvailableDetail: data,
             payloadAvailableAt: data.received_at,
             payloadAvailableBlockHash: data.block_hash,
             payloadAvailableBuilder: data.builder_index

--- a/pkg/webui/src/hooks/useProposerPreferences.ts
+++ b/pkg/webui/src/hooks/useProposerPreferences.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { REFRESH_INTERVAL_LIVE_MS } from './refreshIntervals';
 import type { ProposerPreference, ProposerPreferencesResponse } from '../types';
 
 export function useProposerPreferences() {
@@ -37,8 +38,8 @@ export function useProposerPreferences() {
 
   useEffect(() => {
     fetchPreferences();
-    // Poll every 12 seconds (one slot) — preferences change slot-by-slot
-    const interval = setInterval(fetchPreferences, 12000);
+    // Preferences change slot-by-slot; live tier, only while the page is open.
+    const interval = setInterval(fetchPreferences, REFRESH_INTERVAL_LIVE_MS);
     return () => clearInterval(interval);
   }, []);
 

--- a/pkg/webui/src/pages/DashboardPage.tsx
+++ b/pkg/webui/src/pages/DashboardPage.tsx
@@ -28,7 +28,10 @@ const DashboardPage: React.FC = () => {
     clearEvents
   } = useEventStream();
 
-  const { status: builderAPIStatus, loading: builderAPIStatusLoading } = useBuilderAPIStatus();
+  // Refetch the Builder API status card when the SSE-delivered enable flag
+  // flips — the background poll itself runs on the slow shared interval.
+  const { status: builderAPIStatus, loading: builderAPIStatusLoading } =
+    useBuilderAPIStatus(serviceStatus?.builder_api_enabled);
 
   // The events panel must scroll internally rather than expand the page. A pure
   // CSS flex chain can't express "fill remaining viewport height, OR match the

--- a/pkg/webui/src/pages/DashboardPage.tsx
+++ b/pkg/webui/src/pages/DashboardPage.tsx
@@ -96,8 +96,12 @@ const DashboardPage: React.FC = () => {
                       Only {voteCoverage.seen_pct.toFixed(0)}% of the attesters that landed
                       on chain were seen as raw single attestations (last{' '}
                       {voteCoverage.slots} blocks). The beacon node is likely running
-                      without subscribe-all-subnets, so the head-vote graph is unreliable
-                      and has been hidden.
+                      without subscribe-all-subnets, so live vote tracking undercounts
+                      participation: the head-vote graph has been hidden, and{' '}
+                      <strong>vote-threshold-gated payload reveals are unreliable</strong>{' '}
+                      — the reveal vote gate opens late or never (payloads may be
+                      withheld at slot end). Use a time-based reveal gate or fix the
+                      subnet subscription.
                       <br />
                       Enable it via <code>--subscribe-all-subnets</code>{' '}
                       (Lighthouse/Prysm/Nimbus/Grandine),{' '}

--- a/pkg/webui/src/styles.css
+++ b/pkg/webui/src/styles.css
@@ -381,6 +381,12 @@
   border: 2px solid #cc9a06;
 }
 
+/* Artifact download buttons at the bottom of event popovers */
+.popover-artifacts {
+  padding: 6px 12px 8px;
+  border-top: 1px solid var(--bs-border-color);
+}
+
 /* Low vote coverage warning badge + hover callout (slot timeline header) */
 .coverage-warning {
   position: relative;

--- a/pkg/webui/src/types.ts
+++ b/pkg/webui/src/types.ts
@@ -167,12 +167,14 @@ export interface RevealEvent {
 export interface RevealAttempt {
   time: number;
   startedAt?: number;
+  transport?: string;
   success: boolean;
   skipped: boolean;
   skipReason?: string;
   error?: string;
   attempt: number;
   maxAttempts: number;
+  envelope?: EnvelopeDetail;
 }
 
 // Raw single-attestation subnet coverage vs. next-block attesters. `low` marks
@@ -213,6 +215,76 @@ export interface HeadVoteDataPoint {
   thresholdMet?: boolean;
 }
 
+// Execution payload envelope summary (payload_available / reveal events;
+// list fields aggregated to counts).
+export interface EnvelopeDetail {
+  block_hash?: string;
+  builder_index?: number;
+  block_number?: number;
+  gas_limit?: number;
+  gas_used?: number;
+  base_fee_per_gas?: string;
+  extra_data?: string;
+  blob_gas_used?: number;
+  num_transactions?: number;
+  num_withdrawals?: number;
+  num_exec_requests?: number;
+}
+
+// Display summary of an imported beacon block (block_detail event; list
+// fields aggregated to counts).
+export interface BlockDetail {
+  slot: number;
+  proposer_index: number;
+  parent_root: string;
+  state_root: string;
+  graffiti: string; // 0x-hex
+  num_attestations: number;
+  num_proposer_slashings?: number;
+  num_attester_slashings?: number;
+  num_deposits?: number;
+  num_voluntary_exits?: number;
+  num_bls_changes?: number;
+  sync_participation: number;
+  num_blob_commitments?: number;
+  num_payload_attestations?: number;
+  bid?: {
+    builder_index: number;
+    value_gwei: number;
+    execution_payment_gwei: number;
+    block_hash: string;
+    parent_block_hash: string;
+    gas_limit: number;
+    fee_recipient: string;
+    num_blob_kzgs?: number;
+  };
+  payload?: {
+    block_number: number;
+    block_hash: string;
+    gas_limit: number;
+    gas_used: number;
+    num_transactions: number;
+    num_withdrawals: number;
+  };
+}
+
+// Full built-payload properties from the payload_ready event (transactions,
+// withdrawals, blobs, execution requests aggregated to counts).
+export interface PayloadDetail {
+  blockNumber?: number;
+  feeRecipient?: string;
+  gasLimit?: number;
+  gasUsed?: number;
+  baseFeePerGas?: string; // wei
+  extraData?: string; // 0x-hex
+  blobGasUsed?: number;
+  excessBlobGas?: number;
+  numTransactions?: number;
+  numWithdrawals?: number;
+  numBlobs?: number;
+  numExecRequests?: number;
+}
+
 // UI State types
 export interface SlotState {
   slot: number;
@@ -243,6 +315,12 @@ export interface SlotState {
   // Set while a reveal attempt's submit call is in flight (cleared by the
   // completion event); drives the live-growing call span.
   revealInFlight?: { attempt: number; startedAt: number };
+  // Full built-payload properties (list fields aggregated to counts).
+  payloadDetail?: PayloadDetail;
+  // Imported block summary (from the block_detail event).
+  blockDetail?: BlockDetail;
+  // Envelope summary attached to the payload_available event.
+  payloadAvailableDetail?: EnvelopeDetail;
   headVotes?: HeadVoteDataPoint[];
   headVoteThresholdPct?: number;
   headVoteThresholdMetAt?: number;
@@ -274,9 +352,12 @@ export interface PayloadAttributesInfo {
   parentBlockRoot: string;
   parentBlockNumber: number;
   timestamp: number;
+  prevRandao?: string;
   feeRecipient: string;
+  parentBeaconBlockRoot?: string;
   targetGasLimit: number;
   withdrawalsCount: number;
+  inclusionListCount?: number;
   receivedAt: number;
 }
 
@@ -287,6 +368,14 @@ export interface OurBid {
   count: number;
   success: boolean;
   error?: string;
+  // Full bid message properties (blob commitments aggregated to a count).
+  executionPayment?: number;
+  feeRecipient?: string;
+  gasLimit?: number;
+  builderIndex?: number;
+  parentBlockHash?: string;
+  parentBlockRoot?: string;
+  numBlobCommitments?: number;
 }
 
 export interface ExternalBid {
@@ -294,6 +383,13 @@ export interface ExternalBid {
   value: number;
   builder: number;
   blockHash?: string;
+  // Full bid message properties (blob commitments aggregated to a count).
+  executionPayment?: number;
+  feeRecipient?: string;
+  gasLimit?: number;
+  parentBlockHash?: string;
+  parentBlockRoot?: string;
+  numBlobCommitments?: number;
 }
 
 export interface LogEvent {
@@ -565,8 +661,39 @@ export interface BuildOutcome {
   num_transactions?: number;
   num_blobs?: number;
   fee_recipient?: string;
+  // Full built-payload properties (list fields aggregated to counts).
+  block_number?: number;
+  parent_hash?: string;
+  state_root?: string;
+  receipts_root?: string;
+  prev_randao?: string;
+  timestamp?: number;
+  gas_limit?: number;
+  gas_used?: number;
+  base_fee_per_gas?: string;
+  extra_data?: string;
+  blob_gas_used?: number;
+  excess_blob_gas?: number;
+  num_withdrawals?: number;
+  num_execution_requests?: number;
+  attributes?: AttributesSnapshot;
   error?: string;
   at: string;
+}
+
+// The payload_attributes snapshot a build ran on (list fields aggregated).
+export interface AttributesSnapshot {
+  proposer_index: number;
+  parent_block_root: string;
+  parent_block_hash: string;
+  parent_block_number: number;
+  timestamp: number;
+  prev_randao: string;
+  suggested_fee_recipient: string;
+  parent_beacon_block_root?: string;
+  target_gas_limit?: number;
+  num_withdrawals: number;
+  num_inclusion_list_txs?: number;
 }
 
 export interface SlotBidAttempt {
@@ -576,6 +703,15 @@ export interface SlotBidAttempt {
   execution_payment_gwei?: number;
   competitor_high_gwei?: number;
   artifact_index?: number;
+  // Full bid message properties (blob commitments aggregated to a count).
+  block_hash?: string;
+  parent_block_hash?: string;
+  parent_block_root?: string;
+  prev_randao?: string;
+  fee_recipient?: string;
+  gas_limit?: number;
+  builder_index?: number;
+  num_blob_commitments?: number;
   error?: string;
   at: string;
 }
@@ -590,10 +726,11 @@ export interface SlotBlockSubmission {
 export interface SlotRevealAttempt {
   status: RevealAttemptStatus;
   transport: string;
-  skip_reason?: string; // "plan_disabled" | "late"
+  skip_reason?: string; // "plan_disabled" | "disabled" | "late" | "vote_gate_timeout"
   error?: string;
   attempt: number;
   at: string;
+  started_at?: string;
 }
 
 export type PayloadCanonicalStatus = 'pending' | 'canonical' | 'missed' | 'orphaned';


### PR DESCRIPTION
# Assorted small fixes & improvements

A collection of independent small fixes collected while running buildoor instances on glamsterdam-devnet-7: two builder-side robustness fixes (gas limit correction, missed-block attributes fallback), richer event inspection in the WebUI, a clearer low-vote-coverage warning, aligned UI polling, and a CI split so branch builds skip the Kurtosis E2E.

## Builder fixes

### Adjust payload gas limit when the EL ignores `targetGasLimit` (79273c6)

Every p2p bid from the geth-backed devnet instance was rejected by Lighthouse gossip validation with `InvalidGasLimit`. Gloas bid validation requires the bid's gas limit to *exactly* equal the parent block's committed gas limit moved toward the proposer's preferred target (from gossip proposer preferences) at the maximum per-block step (`max(parent/1024, 1) - 1`). Buildoor passes the resolved target to the EL via the Amsterdam `targetGasLimit` payload attribute, but ELs that don't implement the field yet (e.g. the current devnet geth build) silently drop it and build toward their own configured gas limit target — producing payloads whose bids can never pass gossip validation.

Since buildoor already rebuilds the execution block header to inject its extra-data marker, it now corrects the gas limit in the same pass:

- `BlockInfo` (beacon client) exposes the block's committed execution gas limit — the bid's `gas_limit` from Gloas on (matching what consensus validation compares against, even for withheld payloads), the embedded payload's before.
- `expectedBidGasLimit()` mirrors the consensus stepping rule (with a table-driven test).
- While the EL builds, the payload builder fetches the parent block's committed gas limit and computes the expected value; if the returned payload's gas limit differs, it is overridden before the block hash is recomputed. Bids and reveals pick the corrected value up automatically since both derive from the payload.
- The override is skipped (with a warning) in the one case it can't be applied: when the EL packed more gas than the expected limit allows (only possible when stepping down).
- `ModifyPayloadExtraData` is now `ModifyPayload`, covering both header rewrites in one hash recompute.

### Reuse last payload attributes when the CL emits none on a missed block (bd7300e)

Some CL clients never re-emit `payload_attributes` when a slot's block goes missing entirely, leaving the builder without a build trigger for the next slot. Each received attributes event now arms a one-shot fallback check for the following proposal slot, firing at its build start time: if no attributes arrived by then, the last received attributes (searched back up to 8 slots to cover runs of missing blocks) are re-used with the proposal slot advanced and the timestamp moved forward — everything else stays identical since no new block was built. The synthesized event is injected into the normal event stream, so it flows through the exact same build path as a node-received one. Covered by unit tests.

## WebUI

### More details in event callouts (85b41d8, 480e572)

The slot timeline event callouts now carry full display summaries instead of bare hashes:

- Bid, built-payload and envelope events include the complete message properties (list fields aggregated to counts: transactions, withdrawals, blobs, execution requests).
- New `block_detail` SSE event: a summary of every imported beacon block (extracted from the head vote tracker's coverage fetch), including graffiti and the winning builder bid (Gloas+) or the in-block payload (pre-Gloas).
- Envelope summaries are attached to reveal attempts at construction time, so failed/withheld publishes stay inspectable in the UI.
- Artifact download links (SSZ/JSON) directly from bid callouts via the new `BidArtifactLinks` component.
- Swagger/API docs regenerated for the new event payloads and the extended reveal skip reasons (`plan_disabled | disabled | late | vote_gate_timeout`) and `started_at` attempt field.

### Clearer low vote coverage warning (25c373f)

The low-subnet-coverage warning (log + dashboard banner) now spells out the actual impact: single-attestation tracking undercounts participation, so vote-threshold-gated payload reveals become unreliable — the vote gate opens late or never and payloads may be withheld at slot end. The banner suggests switching to a time-based reveal gate or fixing the subnet subscription (subscribe-all-subnets).

### Aligned UI refresh intervals (8272514)

REST background polling is now centralized in `refreshIntervals.ts`: SSE is the live update channel, so REST refreshes only guard against slow drift. Near-static data polls at 60s, genuinely slot-by-slot data (proposer preferences page) at 12s and only while its page is open — instead of each hook picking its own cadence.

## CI

### Skip E2E on branch builds (92da148)

The Kurtosis E2E moved out of `_shared-check.yaml` into its own `_shared-e2e.yaml`, wired into the PR workflow only and gated on the code checks (no enclave spin-up for broken code). Branch/main builds run the code checks alone.

## Testing

- `go test ./...` passes; new unit tests for the gas limit stepping rule and the attributes fallback.
- Gas limit fix diagnosed and verified against a live glamsterdam-devnet-7 instance where geth stepped the gas limit down from the network's 300M target each block (`parent - (parent/1024 - 1)`), causing 100% bid rejection; with the correction the expected bid gas limit matches what Lighthouse's `is_gas_limit_target_compatible` accepts.
