### PR TITLE
WebUI builder exit button & exited-key safety

### DIFF
--- a/pkg/chain/constants.go
+++ b/pkg/chain/constants.go
@@ -13,3 +13,14 @@ func IsBuilderActive(info *BuilderInfo, finalizedEpoch uint64) bool {
 	}
 	return info.DepositEpoch < finalizedEpoch && info.WithdrawableEpoch == FarFutureEpoch
 }
+
+// HasBuilderExited returns true when the builder's exit has been initiated
+// (withdrawable epoch set). Per the Gloas spec an exited builder can never be
+// reactivated: a deposit for its pubkey only tops up the exited entry and is
+// withdrawn back to the execution address by the sweep (pushing the withdrawable
+// epoch out by MIN_BUILDER_WITHDRAWABILITY_DELAY if the entry was already swept).
+// The pubkey only becomes depositable again once the entry's index is reused by a
+// different builder's deposit and the pubkey leaves the registry (info == nil).
+func HasBuilderExited(info *BuilderInfo) bool {
+	return info != nil && info.WithdrawableEpoch != FarFutureEpoch
+}

--- a/pkg/chain/constants_test.go
+++ b/pkg/chain/constants_test.go
@@ -1,0 +1,26 @@
+package chain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHasBuilderExited(t *testing.T) {
+	tests := []struct {
+		name string
+		info *BuilderInfo
+		want bool
+	}{
+		{name: "nil info (pubkey not in registry)", info: nil, want: false},
+		{name: "active builder", info: &BuilderInfo{WithdrawableEpoch: FarFutureEpoch}, want: false},
+		{name: "exit initiated", info: &BuilderInfo{WithdrawableEpoch: 1234}, want: true},
+		{name: "exit at epoch zero", info: &BuilderInfo{WithdrawableEpoch: 0}, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, HasBuilderExited(tt.info))
+		})
+	}
+}

--- a/pkg/lifecycle/balance.go
+++ b/pkg/lifecycle/balance.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ethpandaops/go-eth2-client/spec/phase0"
 	"github.com/sirupsen/logrus"
 
+	"github.com/ethpandaops/buildoor/pkg/chain"
 	"github.com/ethpandaops/buildoor/pkg/config"
 	"github.com/ethpandaops/buildoor/pkg/payload_bidder"
 	"github.com/ethpandaops/buildoor/pkg/rpc/beacon"
@@ -101,7 +102,14 @@ func (s *BalanceService) GetEffectiveBalance(ctx context.Context) (uint64, error
 }
 
 // NeedsTopup checks if a top-up is needed and returns the required amount.
+// It returns ErrBuilderExited for a builder whose exit has been initiated: after the
+// sweep zeroes the balance a top-up would otherwise trigger every cooldown, cycling
+// funds wallet -> exited entry -> (64 epochs locked) -> wallet forever.
 func (s *BalanceService) NeedsTopup(ctx context.Context) (bool, uint64, error) {
+	if chain.HasBuilderExited(s.depositSvc.chainSvc.GetBuilderByPubkey(s.depositSvc.signer.PublicKey())) {
+		return false, 0, ErrBuilderExited
+	}
+
 	effectiveBalance, err := s.GetEffectiveBalance(ctx)
 	if err != nil {
 		return false, 0, err

--- a/pkg/lifecycle/deposit.go
+++ b/pkg/lifecycle/deposit.go
@@ -30,6 +30,13 @@ var ErrContractNotActive = errors.New("builder deposit contract not active yet")
 // addresses than this build expects.
 var ErrContractNotDeployed = errors.New("builder system contract not deployed")
 
+// ErrBuilderExited is returned when a deposit/top-up targets a builder whose exit has
+// been initiated. Exited builders can never be reactivated: the deposit would only top
+// up the exited registry entry and be withdrawn back to the wallet by the sweep. The
+// pubkey becomes depositable again only once it leaves the builder registry (its index
+// is reused by a different builder's deposit).
+var ErrBuilderExited = errors.New("builder has exited and cannot be reactivated; deposits are disabled until the pubkey leaves the builder registry")
+
 // isDepositDeferred reports whether err indicates a deposit/top-up that should be
 // delayed and retried later (queue fee over the limit, or contract not yet active
 // or deployed) rather than treated as a hard failure.
@@ -107,9 +114,16 @@ func (s *DepositService) IsBuilderRegistered(_ context.Context) (bool, *BuilderS
 // DepositMaxFeeGwei is set, returns ErrDepositFeeTooHigh if the fee exceeds the limit
 // so the caller can delay and retry. The transaction value is stake + queue fee.
 func (s *DepositService) CreateDeposit(ctx context.Context, amountGwei uint64) error {
-	s.log.WithField("amount_gwei", amountGwei).Info("Creating builder deposit")
-
 	pubkey := s.signer.PublicKey()
+
+	// Refuse deposits for an exited builder entry: they cannot reactivate it and
+	// are withdrawn back to the wallet, minus gas and the queue fee. A fresh
+	// registration (pubkey absent from the registry) passes this check.
+	if chain.HasBuilderExited(s.chainSvc.GetBuilderByPubkey(pubkey)) {
+		return ErrBuilderExited
+	}
+
+	s.log.WithField("amount_gwei", amountGwei).Info("Creating builder deposit")
 	withdrawalCredentials := BuilderWithdrawalCredentials(s.wallet.Address())
 
 	// Step 1: Compute the builder-deposit signing root (DOMAIN_BUILDER_DEPOSIT,

--- a/pkg/lifecycle/manager.go
+++ b/pkg/lifecycle/manager.go
@@ -4,6 +4,7 @@ package lifecycle
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -60,7 +61,10 @@ type Manager struct {
 	depositPendingCallback func()
 	registrationDone       atomic.Bool
 	enabled                atomic.Bool
-	eventCallback          func(*LifecycleEvent)
+	// exitNoticed dedupes the exited-builder warning event; re-armed when the
+	// pubkey shows up unexited again (fresh registration after registry reuse).
+	exitNoticed   atomic.Bool
+	eventCallback func(*LifecycleEvent)
 }
 
 // NewManager creates a new lifecycle manager.
@@ -199,6 +203,10 @@ func (m *Manager) EnsureBuilderRegistered(ctx context.Context) error {
 		m.fireEvent("state_change", fmt.Sprintf("Builder already registered (index: %d, balance: %d gwei)", state.Index, state.Balance), "info")
 		m.onRegistered(state.Index)
 
+		if state.WithdrawableEpoch != chain.FarFutureEpoch {
+			m.noticeExitOnce(state.WithdrawableEpoch)
+		}
+
 		return nil
 	}
 
@@ -246,6 +254,21 @@ func (m *Manager) InitiateExit(ctx context.Context) error {
 	// whether an exit can be submitted.
 	if !isRegistered {
 		return fmt.Errorf("builder not registered")
+	}
+
+	// Check the live chain entry, not the cached state: an already-exited builder
+	// fails is_active_builder on the beacon side, so a second request only wastes
+	// the queue fee.
+	info := m.chainSvc.GetBuilderByPubkey(m.signer.PublicKey())
+	if chain.HasBuilderExited(info) {
+		return fmt.Errorf("builder exit already initiated (withdrawable epoch %d)", info.WithdrawableEpoch)
+	}
+
+	// The beacon chain silently ignores exit requests while the builder has pending
+	// payments (get_pending_balance_to_withdraw_for_builder != 0) — the transaction
+	// would confirm but the exit never happen.
+	if info != nil && info.PendingPayments > 0 {
+		return fmt.Errorf("builder has %d gwei in pending payments; the exit request would be ignored on chain — retry after they settle", info.PendingPayments)
 	}
 
 	m.fireEvent("exit", fmt.Sprintf("Submitting builder exit for builder index %d", builderIndex), "info")
@@ -648,7 +671,13 @@ func (m *Manager) runBalanceMonitor(ctx context.Context) {
 
 			needsTopup, amount, err := m.balanceSvc.NeedsTopup(ctx)
 			if err != nil {
-				m.log.WithError(err).Warn("Balance check failed")
+				if errors.Is(err, ErrBuilderExited) {
+					// Expected steady state after an exit; the one-time warning
+					// event already fired from refreshBuilderState.
+					m.log.Debug("Builder has exited, skipping top-up check")
+				} else {
+					m.log.WithError(err).Warn("Balance check failed")
+				}
 
 				continue
 			}
@@ -679,6 +708,23 @@ func (m *Manager) runBalanceMonitor(ctx context.Context) {
 	}
 }
 
+// noticeExitOnce logs and fires the exited-builder warning the first time an
+// initiated exit is seen on chain: the key can never be reactivated, so top-ups
+// stay disabled until the pubkey leaves the builder registry.
+func (m *Manager) noticeExitOnce(withdrawableEpoch uint64) {
+	if !m.exitNoticed.CompareAndSwap(false, true) {
+		return
+	}
+
+	m.log.WithField("withdrawable_epoch", withdrawableEpoch).
+		Warn("Builder exit initiated; top-ups disabled (an exited builder cannot be reactivated)")
+	m.fireEvent("state_change",
+		fmt.Sprintf(
+			"Builder exit initiated (withdrawable epoch %d). The key cannot be reactivated — deposits would be withdrawn back to the wallet, so top-ups are disabled until the pubkey leaves the builder set.",
+			withdrawableEpoch),
+		"warning")
+}
+
 // refreshBuilderState updates the cached builder state from the chain service.
 func (m *Manager) refreshBuilderState() {
 	pubkey := m.signer.PublicKey()
@@ -686,6 +732,14 @@ func (m *Manager) refreshBuilderState() {
 
 	if info == nil {
 		return
+	}
+
+	if chain.HasBuilderExited(info) {
+		m.noticeExitOnce(info.WithdrawableEpoch)
+	} else {
+		// The pubkey shows up unexited again (fresh registration after the old
+		// entry left the registry) — re-arm the warning for a future exit.
+		m.exitNoticed.Store(false)
 	}
 
 	m.stateMu.Lock()

--- a/pkg/webui/handlers/api/events.go
+++ b/pkg/webui/handlers/api/events.go
@@ -501,6 +501,11 @@ type EventStreamManager struct {
 	slotStates   map[phase0.Slot]*SlotStateEvent
 	slotStatesMu sync.RWMutex
 
+	// Head roots already broadcast per slot (guarded by slotStatesMu). The BN
+	// may emit repeated head events for the same block; only the first per
+	// (slot, root) is forwarded so followups don't re-stamp the received time.
+	seenHeadRoots map[phase0.Slot]map[phase0.Root]struct{}
+
 	// Track last sent stats to avoid spam
 	lastStats   StatsResponse
 	lastStatsMu sync.Mutex
@@ -546,10 +551,11 @@ func NewEventStreamManager(
 		// across restarts: clients keep their highest processed seq to
 		// dedupe replays and would otherwise drop every event after a
 		// restart.
-		seq:        uint64(time.Now().UnixMicro()),
-		ctx:        ctx,
-		cancel:     cancel,
-		slotStates: make(map[phase0.Slot]*SlotStateEvent, 16),
+		seq:           uint64(time.Now().UnixMicro()),
+		ctx:           ctx,
+		cancel:        cancel,
+		slotStates:    make(map[phase0.Slot]*SlotStateEvent, 16),
+		seenHeadRoots: make(map[phase0.Slot]map[phase0.Root]struct{}, 16),
 	}
 }
 
@@ -1146,18 +1152,25 @@ func (m *EventStreamManager) handleBidSubmissionEvent(event *p2p_bidder.BidSubmi
 }
 
 func (m *EventStreamManager) handleHeadEvent(event *beacon.HeadEvent) {
-	m.broadcastForSlot(event.Slot, &StreamEvent{
-		Type:      EventTypeHeadReceived,
-		Timestamp: time.Now().UnixMilli(),
-		Data: HeadReceivedEvent{
-			Slot:       uint64(event.Slot),
-			BlockRoot:  fmt.Sprintf("0x%x", event.Block[:]),
-			ReceivedAt: time.Now().UnixMilli(),
-		},
-	})
+	// Forward only the first head event per (slot, root); the BN may re-emit
+	// the same block and a followup would re-stamp the received time. A new
+	// root for the slot (reorg) still passes.
+	m.slotStatesMu.Lock()
+
+	roots, ok := m.seenHeadRoots[event.Slot]
+	if !ok {
+		roots = make(map[phase0.Root]struct{}, 1)
+		m.seenHeadRoots[event.Slot] = roots
+	}
+
+	if _, seen := roots[event.Block]; seen {
+		m.slotStatesMu.Unlock()
+		return
+	}
+
+	roots[event.Block] = struct{}{}
 
 	// Update slot state - bidding closed
-	m.slotStatesMu.Lock()
 	if state, ok := m.slotStates[event.Slot]; ok {
 		state.BidsClosed = true
 	} else {
@@ -1167,6 +1180,16 @@ func (m *EventStreamManager) handleHeadEvent(event *beacon.HeadEvent) {
 		}
 	}
 	m.slotStatesMu.Unlock()
+
+	m.broadcastForSlot(event.Slot, &StreamEvent{
+		Type:      EventTypeHeadReceived,
+		Timestamp: time.Now().UnixMilli(),
+		Data: HeadReceivedEvent{
+			Slot:       uint64(event.Slot),
+			BlockRoot:  fmt.Sprintf("0x%x", event.Block[:]),
+			ReceivedAt: time.Now().UnixMilli(),
+		},
+	})
 
 	m.broadcastSlotState(event.Slot)
 }
@@ -1575,6 +1598,12 @@ func (m *EventStreamManager) cleanupOldSlots(currentSlot phase0.Slot) {
 	for slot := range m.slotStates {
 		if currentSlot > phase0.Slot(keepSlots) && slot < currentSlot-phase0.Slot(keepSlots) {
 			delete(m.slotStates, slot)
+		}
+	}
+
+	for slot := range m.seenHeadRoots {
+		if currentSlot > phase0.Slot(keepSlots) && slot < currentSlot-phase0.Slot(keepSlots) {
+			delete(m.seenHeadRoots, slot)
 		}
 	}
 }

--- a/pkg/webui/src/components/BuilderInfo.tsx
+++ b/pkg/webui/src/components/BuilderInfo.tsx
@@ -148,6 +148,18 @@ export const BuilderInfo: React.FC<BuilderInfoProps> = ({ builderInfo, serviceSt
         )}
       </div>
       <div className="card-body p-2">
+        {/* Exited-key warning: per the Gloas spec an exited builder can never be
+            reactivated — deposits to the pubkey only top up the exited entry and
+            are swept back to the wallet, so top-ups are disabled */}
+        {(registrationState === 'exiting' || registrationState === 'exited') && (
+          <div className="alert alert-warning py-2 px-2 small mb-2">
+            <i className="fas fa-exclamation-triangle me-1"></i>
+            <strong>Builder key {registrationState === 'exited' ? 'exited' : 'exiting'} — cannot be reactivated.</strong>{' '}
+            Deposits to this key only top up the exited entry and are withdrawn back to the wallet,
+            so automatic top-ups are disabled. The key becomes usable for a fresh registration only
+            after its registry slot is reused by another builder&apos;s deposit.
+          </div>
+        )}
         <table className="table table-sm table-borderless mb-0">
           <tbody>
             {/* Builder Identity */}


### PR DESCRIPTION
# WebUI builder exit button & exited-key safety

Adds a builder exit button to the WebUI and hardens the lifecycle around what an exit actually means on chain. While reviewing the exit flow against the Gloas consensus specs, it turned out that an exited builder key is effectively **burned** — and that buildoor's auto-topup would cycle funds through the exited entry forever. This PR ships the button together with the guards and UI flagging that make exiting safe.

## Builder exit button

### WebUI exit button (6528f88)

The Builder Info card gains an "Exit Builder" button (visible when lifecycle management is available, the operator is logged in, and the builder is `registered`/`pending_finalization`) with an inline confirm → submitting → done/error flow. It calls the existing `POST /api/lifecycle/exit` endpoint, which submits an EIP-8282 builder exit request through the exit system contract.

Also fixes `Manager.InitiateExit` gating: it rejected builder index 0, but 0 is a valid builder index — only the registration flag tells whether an exit can be submitted.

### EIP-8282 predeploy address update + code guard (c10506c)

Updates the builder deposit/exit predeploy addresses to the current EIP-8282 draft (ethereum-genesis-generator#300). Since a stale address would silently accept requests as plain value transfers (an empty account reads storage slot 0 as zero, indistinguishable from an active contract with an empty queue), `ReadQueueFee` now verifies code exists at the contract address first and fails loudly with `ErrContractNotDeployed` otherwise. Before the Amsterdam fork this is the normal "not yet deployed" state and is treated as deferred, like a too-high queue fee.

### Exit gas limit raise (c55b571)

The current EIP-8282 exit predeploy consumes ~590k gas for a request append (observed on glamsterdam-devnet-7), far above the ~100k an EIP-7002-style append would suggest. The exit gas limit now matches the deposit gas limit (1M).

## Exited builder keys are burned

Checked against the Gloas consensus spec (`process_builder_deposit_request`): once `initiate_builder_exit` sets `withdrawable_epoch` (current + `MIN_BUILDER_WITHDRAWABILITY_DELAY` = 64 epochs), the builder permanently fails `is_active_builder`. A later deposit for the same pubkey never re-registers it — while the pubkey is still in `state.builders` it is treated as a top-up of the exited entry, and if the entry was already swept (balance 0), the deposit *resets* `withdrawable_epoch` to now+64, locking the funds for another 64 epochs before the sweep returns them to the wallet. The spec says it outright:

> *Exited builders cannot be reactivated, although a newly registered builder's public key may have previously appeared in the builder set.*

The pubkey only becomes depositable again once its registry index is reused by a **different** builder's deposit (`get_index_for_new_builder` overwrites swept slots), removing the pubkey from the registry — on a devnet with few builders, potentially never. Once it's gone, `GetBuilderByPubkey` returns nil and the normal registration flow deposits fresh (a restart picks this up automatically).

Without guards this was a live money-cycling bug: after the sweep zeroes the balance, `NeedsTopup` sees `0 < threshold` and the auto-topup deposits into the exited entry every cooldown — wallet → exited entry → (64 epochs locked) → wallet, burning gas + queue fee each round, forever.

### Lifecycle guards

- `chain.HasBuilderExited(info)`: shared predicate for "exit initiated" (`WithdrawableEpoch != FAR_FUTURE_EPOCH`), with a table-driven test.
- New `lifecycle.ErrBuilderExited`, refused by both `DepositService.CreateDeposit` (the single choke point for deposits *and* top-ups; a fresh registration with the pubkey absent from the registry still passes) and `BalanceService.NeedsTopup`. The balance monitor treats it as a quiet steady state (debug log); the manual `/api/lifecycle/topup` endpoint returns the error to the caller.
- `Manager.InitiateExit` checks the live chain entry (not the 1-minute-stale cached state) and rejects:
  - already-exited builders — the beacon side ignores the request anyway, so a second exit only wastes the queue fee;
  - builders with pending payments — per spec, `process_builder_exit_request` silently no-ops while `get_pending_balance_to_withdraw_for_builder != 0`, so the transaction would confirm but the exit never happen.
- One-time `state_change` warning event (`noticeExitOnce`) the first time an initiated exit is seen on chain — including at startup after a restart — re-armed if the key ever shows up freshly registered again.

### WebUI exited-key flag

The Builder Info card shows an amber callout when the registration state is `exiting`/`exited`: the key cannot be reactivated, deposits to it are withdrawn back to the wallet, automatic top-ups are disabled, and the key only becomes usable again after its registry slot is reused by another builder's deposit. The exit button itself is already hidden in those states.
