### PR TITLE
send the Eth-Blob-Data-Included header on envelope submission

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/OffchainLabs/go-bitfield v0.0.0-20251031151322-f427d04d8506
 	github.com/ethereum/go-ethereum v1.17.4
 	github.com/ethpandaops/go-eth-engine-client v0.0.2-0.20260703151703-9761c6187b28
-	github.com/ethpandaops/go-eth2-client v0.1.6
+	github.com/ethpandaops/go-eth2-client v0.1.7-0.20260731014719-0dcfc98f58c3
 	github.com/ethpandaops/service-authenticatoor v0.0.2
 	github.com/glebarez/go-sqlite v1.22.0
 	github.com/goccy/go-yaml v1.19.2

--- a/go.sum
+++ b/go.sum
@@ -68,8 +68,8 @@ github.com/ethereum/go-ethereum v1.17.4 h1:uA4q+qiLp7QImBsjdRbINu8iX6OEVmj4DPc5/
 github.com/ethereum/go-ethereum v1.17.4/go.mod h1:qMdgwqqRAen+aT8P7KKQKi0Qt6RzG4cfejVAbCpJgqA=
 github.com/ethpandaops/go-eth-engine-client v0.0.2-0.20260703151703-9761c6187b28 h1:zPciPcZHSMqL3pJRooPVIVTVAo51PjDX6rYZ6gNJGlU=
 github.com/ethpandaops/go-eth-engine-client v0.0.2-0.20260703151703-9761c6187b28/go.mod h1:ggCXJgxLFNGpC+DkgNQkeTr3dXRQDb0+9niNmaJWAgM=
-github.com/ethpandaops/go-eth2-client v0.1.6 h1:lG7Xz767YQQ+mN1ldzqJlj9Klg6zOElcemjXbCgJV5o=
-github.com/ethpandaops/go-eth2-client v0.1.6/go.mod h1:97Oq3omOQSGPPYgrbsOIIw2Pc4T5Ph21f8ZRyHJQBHU=
+github.com/ethpandaops/go-eth2-client v0.1.7-0.20260731014719-0dcfc98f58c3 h1:her3ynubelIdp45o6nvg+RMoMu4iEx+2xvUjcm94yTg=
+github.com/ethpandaops/go-eth2-client v0.1.7-0.20260731014719-0dcfc98f58c3/go.mod h1:97Oq3omOQSGPPYgrbsOIIw2Pc4T5Ph21f8ZRyHJQBHU=
 github.com/ethpandaops/service-authenticatoor v0.0.2 h1:0rqHA2Rw64+NG0HVGRfqVhJEkRZRzH3qhX2SkBr2u+w=
 github.com/ethpandaops/service-authenticatoor v0.0.2/go.mod h1:nIInMlq5O7YQDLVCL5gf0TeVAvVd9Q50k3sm3abTeG0=
 github.com/ferranbt/fastssz v0.1.4 h1:OCDB+dYDEQDvAgtAGnTSidK1Pe2tW3nFV40XyMkTeDY=

--- a/pkg/rpc/beacon/api.go
+++ b/pkg/rpc/beacon/api.go
@@ -31,10 +31,10 @@ func (c *Client) SubmitExecutionPayloadBid(ctx context.Context, bid *eth2all.Sig
 }
 
 // SubmitExecutionPayloadEnvelope submits a signed execution payload envelope using the
-// stateless flow (SignedExecutionPayloadEnvelopeContents body, Eth-Execution-Payload-Blinded
-// false). The stateful/blinded flow only works when the beacon node cached the full envelope
-// from its own block production (produceBlockV4); buildoor builds payloads externally, so the
-// beacon node never has them cached and the stateless form is the only valid one.
+// stateless flow (SignedExecutionPayloadEnvelopeContents body, Eth-Blob-Data-Included true).
+// The stateful flow only works when the beacon node cached the blob data from its own block
+// production (produceBlockV4); buildoor builds payloads externally, so the beacon node never
+// has them cached and the stateless form is the only valid one.
 //
 // The consensus version header and body encoding (SSZ or JSON per the client's content
 // negotiation) are derived from the envelope's Version by go-eth2-client.


### PR DESCRIPTION
## Summary

Reveals on long-running instances against up-to-date beacon nodes (e.g. `buildoor-lodestar-ethrex-1` on glamsterdam-devnet-7) fail every attempt with:

```
Reveal failed (attempt 3/3): ... POST failed with status 400: {"code":400,"message":"Eth-Blob-Data-Included header is required"}
```

[beacon-APIs#624](https://github.com/ethereum/beacon-APIs/pull/624) renamed the required body-discriminator header on `publishExecutionPayloadEnvelope` from `Eth-Execution-Payload-Blinded` to `Eth-Blob-Data-Included` (`true` = stateless `SignedExecutionPayloadEnvelopeContents` body). Lodestar follows the new spec; go-eth2-client v0.1.6 still sent only the old header.

This bumps `ethpandaops/go-eth2-client` to a version that sends the new header while keeping the old one for beacon nodes that predate the rename (ethpandaops/go-eth2-client#45), and updates the stale header reference in the `SubmitExecutionPayloadEnvelope` doc comment.

## Testing

- `go build ./...` and `go test ./...` pass
