### PR TITLE
Prefer SLOT_DURATION_MS over the stale SECONDS_PER_SLOT when parsing the chain spec

### DIFF
--- a/pkg/chain/spec.go
+++ b/pkg/chain/spec.go
@@ -18,6 +18,10 @@ import (
 
 // ChainSpec holds chain specification parameters.
 type ChainSpec struct {
+	// SecondsPerSlot is the slot duration, taken from SLOT_DURATION_MS when the
+	// beacon node serves it (EIP-7782 networks keep serving a stale
+	// SECONDS_PER_SLOT preset default alongside it) and from SECONDS_PER_SLOT
+	// otherwise.
 	SecondsPerSlot time.Duration
 	SlotsPerEpoch  uint64
 
@@ -88,17 +92,27 @@ func ParseChainSpec(specData map[string]string, rawData map[string]json.RawMessa
 // GetChainSpec fetches the chain specification from the beacon node via direct HTTP.
 // This bypasses go-eth2-client's active check so it works before the node is fully ready.
 func (s *ChainSpec) parseSpecData(specData map[string]string, rawData map[string]json.RawMessage) error {
-	secondsPerSlotStr, ok := specData["SECONDS_PER_SLOT"]
-	if !ok {
-		return fmt.Errorf("SECONDS_PER_SLOT not found")
-	}
+	// SLOT_DURATION_MS (EIP-7782) supersedes SECONDS_PER_SLOT; nodes on such
+	// networks still serve a stale SECONDS_PER_SLOT, so it is only a fallback.
+	if slotDurationMs, err := parseSpecUint64(specData, "SLOT_DURATION_MS"); err == nil {
+		if slotDurationMs == 0 {
+			return fmt.Errorf("invalid SLOT_DURATION_MS: 0")
+		}
 
-	secondsPerSlot, err := strconv.ParseUint(secondsPerSlotStr, 10, 64)
-	if err != nil {
-		return fmt.Errorf("invalid SECONDS_PER_SLOT: %w", err)
-	}
+		s.SecondsPerSlot = time.Duration(slotDurationMs) * time.Millisecond
+	} else {
+		secondsPerSlotStr, ok := specData["SECONDS_PER_SLOT"]
+		if !ok {
+			return fmt.Errorf("SLOT_DURATION_MS or SECONDS_PER_SLOT not found")
+		}
 
-	s.SecondsPerSlot = time.Duration(secondsPerSlot) * time.Second
+		secondsPerSlot, err := strconv.ParseUint(secondsPerSlotStr, 10, 64)
+		if err != nil {
+			return fmt.Errorf("invalid SECONDS_PER_SLOT: %w", err)
+		}
+
+		s.SecondsPerSlot = time.Duration(secondsPerSlot) * time.Second
+	}
 
 	slotsPerEpochStr, ok := specData["SLOTS_PER_EPOCH"]
 	if !ok {

--- a/pkg/chain/spec_test.go
+++ b/pkg/chain/spec_test.go
@@ -1,0 +1,74 @@
+package chain
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseChainSpecSlotDuration(t *testing.T) {
+	tests := []struct {
+		name     string
+		specData map[string]string
+		want     time.Duration
+		wantErr  bool
+	}{
+		{
+			// EIP-7782 networks serve a stale SECONDS_PER_SLOT alongside
+			// SLOT_DURATION_MS; the ms value must win.
+			name: "SLOT_DURATION_MS preferred over stale SECONDS_PER_SLOT",
+			specData: map[string]string{
+				"SLOT_DURATION_MS": "6000",
+				"SECONDS_PER_SLOT": "12",
+				"SLOTS_PER_EPOCH":  "32",
+			},
+			want: 6 * time.Second,
+		},
+		{
+			name: "SECONDS_PER_SLOT fallback",
+			specData: map[string]string{
+				"SECONDS_PER_SLOT": "12",
+				"SLOTS_PER_EPOCH":  "32",
+			},
+			want: 12 * time.Second,
+		},
+		{
+			name: "sub-second SLOT_DURATION_MS",
+			specData: map[string]string{
+				"SLOT_DURATION_MS": "500",
+				"SLOTS_PER_EPOCH":  "32",
+			},
+			want: 500 * time.Millisecond,
+		},
+		{
+			name: "zero SLOT_DURATION_MS rejected",
+			specData: map[string]string{
+				"SLOT_DURATION_MS": "0",
+				"SECONDS_PER_SLOT": "12",
+				"SLOTS_PER_EPOCH":  "32",
+			},
+			wantErr: true,
+		},
+		{
+			name: "neither slot duration key present",
+			specData: map[string]string{
+				"SLOTS_PER_EPOCH": "32",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec, err := ParseChainSpec(tt.specData, nil)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.want, spec.SecondsPerSlot)
+		})
+	}
+}


### PR DESCRIPTION
## Problem

On glamsterdam-devnet-7 buildoor was building bad blocks and generally operating a slot-and-a-half behind the chain: builds scheduled after their slot had passed (`no payload ID returned`, `Too deep reorg` engine errors), `getHeader: slot too far ahead` rejections for legitimate proposer requests, and spurious reorg detections.

Root cause: EIP-7782 networks define slot timing via `SLOT_DURATION_MS` (6000 on devnet-7), but the beacon API keeps serving the `SECONDS_PER_SLOT` preset default (12) alongside it as a deprecated leftover. Buildoor's spec parser only read `SECONDS_PER_SLOT`, so every timing calculation (wall-clock slot, build scheduling, bid windows, reveal deadlines) ran 2x slow.

## Fix

`ParseChainSpec` now prefers `SLOT_DURATION_MS` and only falls back to `SECONDS_PER_SLOT` when the ms field is absent. Everything downstream already consumes `ChainSpec.SecondsPerSlot` as a `time.Duration`, so no other code changes are needed. The `*_BPS` deadline fractions (e.g. `PAYLOAD_DUE_BPS`) self-correct since they scale off the same duration.

Added table-driven tests: ms preferred over stale seconds, seconds fallback, sub-second durations, zero/missing rejection.

## Verification

Deployed into a live devnet-7 kurtosis enclave: startup logs `slot_time_ms=6000`, payloads build every 6s slot, and a full ePBS cycle completed (bid submitted -> included -> reveal vote gate at 62.5% -> envelope published, next slot built on our payload). Two slots won within the first minutes.
