### PR TITLE
Make string-typed mutable settings race-safe against concurrent reads

### DIFF
--- a/pkg/action_plan/frozen.go
+++ b/pkg/action_plan/frozen.go
@@ -379,7 +379,7 @@ func resolveBid(plan *SlotPlan, cfg *config.Config, fork version.DataVersion) *R
 		MinGwei:      cfg.EPBS.BidMinAmount,
 		IncreaseGwei: cfg.EPBS.BidIncrease,
 		SubsidyGwei:  cfg.EPBS.BidSubsidy,
-		BidCandidate: cfg.EPBS.BidCandidate,
+		BidCandidate: cfg.EPBS.GetBidCandidate(),
 		Forced:       forced,
 	}
 
@@ -432,7 +432,7 @@ func resolveBuilderAPI(plan *SlotPlan, cfg *config.Config) *ResolvedBuilderAPISe
 
 	resolved := &ResolvedBuilderAPISettings{
 		SubsidyGwei:     cfg.BuilderAPI.BlockValueSubsidyGwei,
-		ServeCandidates: cfg.BuilderAPI.ServeCandidates,
+		ServeCandidates: cfg.BuilderAPI.GetServeCandidates(),
 		Forced:          forced,
 	}
 

--- a/pkg/builderapi/epbs/payload_bid.go
+++ b/pkg/builderapi/epbs/payload_bid.go
@@ -431,7 +431,7 @@ func (h *Handler) matchPayloadForParent(
 	servePolicy string,
 ) (*payload_builder.Payload, *bidMatchError) {
 	if servePolicy == "" {
-		servePolicy = h.cfg.ServeCandidates
+		servePolicy = h.cfg.GetServeCandidates()
 	}
 
 	if payload := h.payloadCache.GetVariant(slot, beacon.AttrParentKey{Root: parentRoot, Hash: parentHash}); payload != nil {

--- a/pkg/config/settings_fields.go
+++ b/pkg/config/settings_fields.go
@@ -3,6 +3,7 @@ package config
 import (
 	"encoding/json"
 	"fmt"
+	"sync"
 )
 
 // Field describes a single mutable setting: how to read and write it on a
@@ -74,6 +75,56 @@ func newField[T comparable](key, flag string, ptr func(*Config) *T) Field {
 	}
 }
 
+// newLockedStringField builds a Field for a string setting that is read
+// through a locked accessor rather than direct struct access (see NM-02: a
+// UI override mutating a plain string field in place while a hot-path reader
+// dereferences it unsynchronized can observe a torn {ptr,len} read and panic
+// on an out-of-bounds slice). mu must return the same *sync.RWMutex the
+// field's accessor method(s) lock — see Config.GetExtraData,
+// EPBSConfig.GetBidCandidate, BuilderAPIConfig.GetServeCandidates,
+// BuildConfig.CandidateMode, RevealConfig.NormalizedGateMode/
+// NormalizedBroadcastValidation.
+func newLockedStringField(key, flag string, ptr func(*Config) *string, mu func(*Config) *sync.RWMutex) Field {
+	return Field{
+		Key:     key,
+		FlagKey: flag,
+		get: func(c *Config) any {
+			m := mu(c)
+			m.RLock()
+			defer m.RUnlock()
+
+			return *ptr(c)
+		},
+		set: func(c *Config, v any) error {
+			tv, ok := v.(string)
+			if !ok {
+				return fmt.Errorf("settings: %s: invalid value type %T", key, v)
+			}
+
+			m := mu(c)
+			m.Lock()
+			*ptr(c) = tv
+			m.Unlock()
+
+			return nil
+		},
+		decode: func(raw json.RawMessage) (any, error) {
+			var x string
+			if err := json.Unmarshal(raw, &x); err != nil {
+				return nil, err
+			}
+
+			return x, nil
+		},
+		equal: func(a, b any) bool {
+			av, aok := a.(string)
+			bv, bok := b.(string)
+
+			return aok && bok && av == bv
+		},
+	}
+}
+
 // Fields returns the registry of all mutable settings, including the per-module
 // enable flags (which are configured via CLI flags exactly like other settings
 // and therefore follow the same default/cli/ui resolution).
@@ -93,32 +144,50 @@ func Fields() []Field {
 		newField(KeyEPBSBidSubsidy, "epbs-bid-subsidy", func(c *Config) *uint64 { return &c.EPBS.BidSubsidy }),
 		newField(KeyEPBSBidValueOverride, "epbs-bid-value-override", func(c *Config) *uint64 { return &c.EPBS.BidValueOverride }),
 		newField(KeyEPBSHeadVoteThreshold, "epbs-vote-threshold", func(c *Config) *uint64 { return &c.EPBS.HeadVoteThresholdPct }),
-		newField(KeyEPBSBidCandidate, "epbs-bid-candidate", func(c *Config) *string { return &c.EPBS.BidCandidate }),
+		newLockedStringField(KeyEPBSBidCandidate, "epbs-bid-candidate",
+			func(c *Config) *string { return &c.EPBS.BidCandidate },
+			func(c *Config) *sync.RWMutex { return &c.EPBS.mu }),
 		newField(KeyEPBSBidCandidateSwitch, "epbs-bid-candidate-switch", func(c *Config) *bool { return &c.EPBS.BidCandidateSwitch }),
 
 		newField(KeyRevealEnabled, "reveal-enabled", func(c *Config) *bool { return &c.Reveal.Enabled }),
-		newField(KeyRevealGateMode, "reveal-gate-mode", func(c *Config) *string { return &c.Reveal.GateMode }),
+		newLockedStringField(KeyRevealGateMode, "reveal-gate-mode",
+			func(c *Config) *string { return &c.Reveal.GateMode },
+			func(c *Config) *sync.RWMutex { return &c.Reveal.mu }),
 		newField(KeyRevealTimeMs, "reveal-time", func(c *Config) *int64 { return &c.Reveal.TimeMs }),
 		newField(KeyRevealVoteThreshold, "reveal-vote-threshold", func(c *Config) *uint64 { return &c.Reveal.VoteThresholdPct }),
-		newField(KeyRevealBroadcastValidation, "reveal-broadcast-validation", func(c *Config) *string { return &c.Reveal.BroadcastValidation }),
+		newLockedStringField(KeyRevealBroadcastValidation, "reveal-broadcast-validation",
+			func(c *Config) *string { return &c.Reveal.BroadcastValidation },
+			func(c *Config) *sync.RWMutex { return &c.Reveal.mu }),
 		newField(KeyRevealMaxAttempts, "reveal-max-attempts", func(c *Config) *uint64 { return &c.Reveal.MaxAttempts }),
 		newField(KeyRevealRetryInterval, "reveal-retry-interval", func(c *Config) *int64 { return &c.Reveal.RetryIntervalMs }),
 		newField(KeyRevealRebindOnReorg, "reveal-rebind-on-reorg", func(c *Config) *bool { return &c.Reveal.RebindOnReorg }),
 
-		newField(KeyBuildCandidateParentFull, "build-candidate-parent-full", func(c *Config) *string { return &c.Build.CandidateParentFull }),
-		newField(KeyBuildCandidateParentEmpty, "build-candidate-parent-empty", func(c *Config) *string { return &c.Build.CandidateParentEmpty }),
-		newField(KeyBuildCandidateGrandparentFull, "build-candidate-grandparent-full", func(c *Config) *string { return &c.Build.CandidateGrandparentFull }),
-		newField(KeyBuildCandidateGrandparentEmpty, "build-candidate-grandparent-empty", func(c *Config) *string { return &c.Build.CandidateGrandparentEmpty }),
+		newLockedStringField(KeyBuildCandidateParentFull, "build-candidate-parent-full",
+			func(c *Config) *string { return &c.Build.CandidateParentFull },
+			func(c *Config) *sync.RWMutex { return &c.Build.mu }),
+		newLockedStringField(KeyBuildCandidateParentEmpty, "build-candidate-parent-empty",
+			func(c *Config) *string { return &c.Build.CandidateParentEmpty },
+			func(c *Config) *sync.RWMutex { return &c.Build.mu }),
+		newLockedStringField(KeyBuildCandidateGrandparentFull, "build-candidate-grandparent-full",
+			func(c *Config) *string { return &c.Build.CandidateGrandparentFull },
+			func(c *Config) *sync.RWMutex { return &c.Build.mu }),
+		newLockedStringField(KeyBuildCandidateGrandparentEmpty, "build-candidate-grandparent-empty",
+			func(c *Config) *string { return &c.Build.CandidateGrandparentEmpty },
+			func(c *Config) *sync.RWMutex { return &c.Build.mu }),
 		newField(KeyBuildParallel, "build-parallel", func(c *Config) *bool { return &c.Build.Parallel }),
 		newField(KeyBuildSpeculativeBuildTime, "build-speculative-build-time", func(c *Config) *uint64 { return &c.Build.SpeculativeBuildTimeMs }),
 		newField(KeyBuildAutoWeakHeadPct, "build-auto-weak-head-pct", func(c *Config) *uint64 { return &c.Build.AutoWeakHeadPct }),
 		newField(KeyBuildEnforceBidGasLimit, "build-enforce-bid-gas-limit", func(c *Config) *bool { return &c.Build.EnforceBidGasLimit }),
 
 		newField(KeyPayloadBuildTime, "payload-build-time", func(c *Config) *uint64 { return &c.PayloadBuildTime }),
-		newField(KeyExtraData, "extra-data", func(c *Config) *string { return &c.ExtraData }),
+		newLockedStringField(KeyExtraData, "extra-data",
+			func(c *Config) *string { return &c.ExtraData },
+			func(c *Config) *sync.RWMutex { return &c.extraDataMu }),
 		newField(KeyBuilderAPISubsidy, "builder-api-subsidy", func(c *Config) *uint64 { return &c.BuilderAPI.BlockValueSubsidyGwei }),
 		newField(KeyBuilderAPIValueOverride, "builder-api-value-override", func(c *Config) *uint64 { return &c.BuilderAPI.ValueOverrideGwei }),
-		newField(KeyBuilderAPIServeCandidates, "builder-api-serve-candidates", func(c *Config) *string { return &c.BuilderAPI.ServeCandidates }),
+		newLockedStringField(KeyBuilderAPIServeCandidates, "builder-api-serve-candidates",
+			func(c *Config) *string { return &c.BuilderAPI.ServeCandidates },
+			func(c *Config) *sync.RWMutex { return &c.BuilderAPI.mu }),
 		newField(KeyBuilderAPIOnDemandBuild, "builder-api-on-demand-build", func(c *Config) *bool { return &c.BuilderAPI.OnDemandBuild }),
 
 		newField(KeySlotResultRetentionEpochs, "slot-result-retention-epochs", func(c *Config) *uint64 { return &c.SlotResultRetentionEpochs }),

--- a/pkg/config/settings_fields_test.go
+++ b/pkg/config/settings_fields_test.go
@@ -1,0 +1,84 @@
+package config
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestLockedStringFields_RaceFree guards against NM-02: a UI override
+// (SetMany/recompute, via Field.Set) racing a live hot-path read of the same
+// string setting. Before the fix, Field.Set mutated the field in place with
+// no lock while every reader dereferenced it unsynchronized — a torn
+// {ptr,len} read could produce an out-of-bounds slice panic, and the field
+// was reachable by any unauthenticated client on --api-port (the Builder
+// API's port). This drives Field.Set (the exact path SetMany/recompute use)
+// against each field's real accessor method concurrently under -race: run
+// with `go test -race` (the default for this repo's CI), any surviving race
+// fails the test.
+func TestLockedStringFields_RaceFree(t *testing.T) {
+	cfg := &Config{}
+	fields := Fields()
+	byKey := make(map[string]Field, len(fields))
+
+	for _, f := range fields {
+		byKey[f.Key] = f
+	}
+
+	// One entry per locked string field: the settings key and the real
+	// accessor method a hot-path reader actually calls.
+	cases := []struct {
+		name   string
+		key    string
+		reader func() string
+	}{
+		{"ExtraData", KeyExtraData, cfg.GetExtraData},
+		{"EPBS.BidCandidate", KeyEPBSBidCandidate, cfg.EPBS.GetBidCandidate},
+		{"BuilderAPI.ServeCandidates", KeyBuilderAPIServeCandidates, cfg.BuilderAPI.GetServeCandidates},
+		{"Reveal.GateMode", KeyRevealGateMode, cfg.Reveal.NormalizedGateMode},
+		{"Reveal.BroadcastValidation", KeyRevealBroadcastValidation, cfg.Reveal.NormalizedBroadcastValidation},
+		{"Build.CandidateParentFull", KeyBuildCandidateParentFull, func() string { return cfg.Build.CandidateMode("parent_full") }},
+		{"Build.CandidateParentEmpty", KeyBuildCandidateParentEmpty, func() string { return cfg.Build.CandidateMode("parent_empty") }},
+		{"Build.CandidateGrandparentFull", KeyBuildCandidateGrandparentFull, func() string { return cfg.Build.CandidateMode("grandparent_full") }},
+		{"Build.CandidateGrandparentEmpty", KeyBuildCandidateGrandparentEmpty, func() string { return cfg.Build.CandidateMode("grandparent_empty") }},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			field, ok := byKey[tc.key]
+			require.True(t, ok, "field %q must be registered", tc.key)
+
+			var wg sync.WaitGroup
+
+			stop := make(chan struct{})
+
+			wg.Add(1)
+
+			go func() {
+				defer wg.Done()
+
+				i := 0
+				for {
+					select {
+					case <-stop:
+						return
+					default:
+					}
+
+					i++
+					_ = field.Set(cfg, "value-"+string(rune('a'+i%26)))
+				}
+			}()
+
+			deadline := time.Now().Add(50 * time.Millisecond)
+			for time.Now().Before(deadline) {
+				_ = tc.reader()
+			}
+
+			close(stop)
+			wg.Wait()
+		})
+	}
+}

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -1,7 +1,10 @@
 // Package config handles configuration loading and validation for buildoor.
 package config
 
-import "strings"
+import (
+	"strings"
+	"sync"
+)
 
 // ValidatorRangesConfig configures how to load validator index → client name mappings.
 // If both are set, URL takes precedence.
@@ -53,7 +56,12 @@ type Config struct {
 	// ExtraData is the prefix injected into the built payload's extra-data field
 	// (then padded with the EL's original extra data, truncated to 32 bytes). Used
 	// to mark blocks built by this builder. Defaulted to "buildoor/" when empty.
+	// A UI override can rewrite this live (settings_fields.go); read it only via
+	// GetExtraData(), never the field directly — extraDataMu is what makes a
+	// concurrent UI write and a build-time read race-free instead of a torn
+	// {ptr,len} read.
 	ExtraData       string                `yaml:"extra_data" json:"extra_data"`
+	extraDataMu     sync.RWMutex
 	ValidatorRanges ValidatorRangesConfig `yaml:"validator_ranges" json:"validator_ranges"`
 	// SlotResultRetentionEpochs is how many epochs of per-slot result history
 	// (plans + outcome summaries) are kept before pruning, in memory and in the
@@ -72,6 +80,15 @@ type Config struct {
 	// proposer preferences and an audit log across restarts. Startup-only and
 	// never itself persisted. Empty disables persistence (in-memory only).
 	StateDBPath string `yaml:"state_db" json:"state_db,omitempty"`
+}
+
+// GetExtraData returns the live-configured extra-data prefix. Race-free
+// against a concurrent UI override (see the ExtraData field comment).
+func (c *Config) GetExtraData() string {
+	c.extraDataMu.RLock()
+	defer c.extraDataMu.RUnlock()
+
+	return c.ExtraData
 }
 
 // ScheduleConfig defines when the builder should build blocks.
@@ -120,13 +137,25 @@ type BuilderAPIConfig struct {
 	// ServeCandidates controls which built candidate payloads bid requests may
 	// be answered from: "all" (default; serve whichever candidate matches the
 	// requested parent), "canonical_only" (only parent_full and unclassified
-	// payloads), or a comma-separated list of candidate keys.
+	// payloads), or a comma-separated list of candidate keys. A UI override can
+	// rewrite this live; read it only via GetServeCandidates(), never the field
+	// directly (see mu).
 	ServeCandidates string `yaml:"serve_candidates" json:"serve_candidates"`
+	mu              sync.RWMutex
 
 	// OnDemandBuild builds a payload on the fly when a bid request asks for a
 	// legal parent tuple no candidate covers yet (bounded by the request's
 	// response budget).
 	OnDemandBuild bool `yaml:"on_demand_build" json:"on_demand_build"`
+}
+
+// GetServeCandidates returns the live-configured serve policy. Race-free
+// against a concurrent UI override (see the ServeCandidates field comment).
+func (c *BuilderAPIConfig) GetServeCandidates() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	return c.ServeCandidates
 }
 
 // ServeCandidateAllowed reports whether the given serve policy allows
@@ -155,7 +184,7 @@ func ServeCandidateAllowed(policy, key string) bool {
 
 // ServeCandidateAllowed applies the config's own serve policy.
 func (c *BuilderAPIConfig) ServeCandidateAllowed(key string) bool {
-	return ServeCandidateAllowed(c.ServeCandidates, key)
+	return ServeCandidateAllowed(c.GetServeCandidates(), key)
 }
 
 // EPBSConfig defines time-scheduled bidding parameters for ePBS.
@@ -200,8 +229,11 @@ type EPBSConfig struct {
 	// status), a specific candidate key (parent_full, parent_empty,
 	// grandparent_full, grandparent_empty), or "all" (gossip a bid for every
 	// built candidate — deliberate multi-parent bidding for gossip testing;
-	// most nodes propagate only a builder's first bid per slot).
+	// most nodes propagate only a builder's first bid per slot). A UI override
+	// can rewrite this live; read it only via GetBidCandidate(), never the
+	// field directly (see mu).
 	BidCandidate string `yaml:"bid_candidate" json:"bid_candidate"`
+	mu           sync.RWMutex
 
 	// BidCandidateSwitch allows the auto selection to switch to a different
 	// candidate mid-slot when the chain view changes. Default off: the first
@@ -216,6 +248,16 @@ type EPBSConfig struct {
 	// (BUILDER_PAYMENT_THRESHOLD_NUMERATOR/DENOMINATOR = 6/10) — the
 	// participation level at which the builder's payment actually settles.
 	HeadVoteThresholdPct uint64 `yaml:"head_vote_threshold_pct" json:"head_vote_threshold_pct"`
+}
+
+// GetBidCandidate returns the live-configured p2p bid candidate selection.
+// Race-free against a concurrent UI override (see the BidCandidate field
+// comment).
+func (c *EPBSConfig) GetBidCandidate() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	return c.BidCandidate
 }
 
 // Candidate build modes: whether a build-parent candidate is built for a slot.
@@ -247,6 +289,9 @@ func NormalizedCandidateMode(mode, fallback string) string {
 // it built upon ("empty", the Gloas payload-miss case).
 type BuildConfig struct {
 	// CandidateParentFull: the normal build on the head block and its payload.
+	// This and the three candidate fields below can be rewritten live by a UI
+	// override; they are only ever read through CandidateMode(), which locks
+	// mu — never read these fields directly.
 	CandidateParentFull string `yaml:"candidate_parent_full" json:"candidate_parent_full"`
 	// CandidateParentEmpty: build on the head block but on its execution
 	// parent (head payload treated as withheld). Gloas only.
@@ -256,6 +301,7 @@ type BuildConfig struct {
 	// CandidateGrandparentEmpty: reorg combined with a withheld grandparent
 	// payload. Gloas only.
 	CandidateGrandparentEmpty string `yaml:"candidate_grandparent_empty" json:"candidate_grandparent_empty"`
+	mu                        sync.RWMutex
 
 	// Parallel runs the selected candidate builds concurrently against the
 	// EL, each with its own payload ID (default). Disable it to serialize
@@ -280,8 +326,12 @@ type BuildConfig struct {
 }
 
 // CandidateMode returns the normalized mode configured for the given
-// candidate key ("" for unknown keys).
+// candidate key ("" for unknown keys). Race-free against a concurrent UI
+// override of any of the four candidate fields (see their comments).
 func (c *BuildConfig) CandidateMode(key string) string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	switch key {
 	case "parent_full":
 		return NormalizedCandidateMode(c.CandidateParentFull, CandidateModeAlways)
@@ -329,8 +379,12 @@ type RevealConfig struct {
 
 	// GateMode decides the reveal moment: time | vote | vote_or_time |
 	// vote_and_time (see the RevealGate* constants). Unknown values fall
-	// back to time.
+	// back to time. This and BroadcastValidation below can be rewritten live
+	// by a UI override; they are only ever read through NormalizedGateMode()/
+	// NormalizedBroadcastValidation(), which lock mu — never read these
+	// fields directly.
 	GateMode string `yaml:"gate_mode" json:"gate_mode"`
+	mu       sync.RWMutex
 
 	// TimeMs is milliseconds relative to slot start for the time gate.
 	// 0 = auto-compute from slot time (see ApplySlotDefaults).
@@ -361,8 +415,12 @@ type RevealConfig struct {
 }
 
 // NormalizedGateMode returns the gate mode, falling back to RevealGateTime
-// for unknown values (UI overrides are free-form strings).
+// for unknown values (UI overrides are free-form strings). Race-free against
+// a concurrent UI override (see the GateMode field comment).
 func (c *RevealConfig) NormalizedGateMode() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	switch c.GateMode {
 	case RevealGateTime, RevealGateVote, RevealGateVoteOrTime, RevealGateVoteAndTime:
 		return c.GateMode
@@ -372,8 +430,12 @@ func (c *RevealConfig) NormalizedGateMode() string {
 }
 
 // NormalizedBroadcastValidation returns the broadcast validation level,
-// falling back to gossip for unknown values.
+// falling back to gossip for unknown values. Race-free against a concurrent
+// UI override (see the GateMode field comment).
 func (c *RevealConfig) NormalizedBroadcastValidation() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	switch c.BroadcastValidation {
 	case BroadcastValidationGossip, BroadcastValidationConsensus,
 		BroadcastValidationConsensusAndEquivocation:

--- a/pkg/p2p_bidder/scheduler.go
+++ b/pkg/p2p_bidder/scheduler.go
@@ -286,7 +286,7 @@ func (s *Scheduler) selectBidPayloads(
 	// frozen before the setting existed.
 	mode := bidSettings.BidCandidate
 	if mode == "" {
-		mode = s.cfg.EPBS.BidCandidate
+		mode = s.cfg.EPBS.GetBidCandidate()
 	}
 
 	switch {

--- a/pkg/payload_builder/payload_builder.go
+++ b/pkg/payload_builder/payload_builder.go
@@ -310,7 +310,7 @@ func (b *PayloadBuilder) BuildPayloadFromAttributes(
 	newHash, err := ModifyPayloadExtraData(
 		enginePayload,
 		resp.ExecutionRequests,
-		[]byte(b.cfg.ExtraData),
+		[]byte(b.cfg.GetExtraData()),
 		common.Hash(attrs.ParentBeaconBlockRoot),
 		gasLimitOverride,
 	)


### PR DESCRIPTION
## Problem

Every mutable setting is mutated in place by `SetMany`/`recompute` with no
lock, while modules holding the shared config read fields directly and
unsynchronized. For the nine string-typed settings (extra data, reveal gate
mode, bid candidate selection, and so on) a UI write racing a hot-path read
can produce a torn pointer/length read and panic on an out-of-bounds slice.

The WebUI and Builder API share the same HTTP port, and the WebUI has no
auth by default, so this is reachable by any client that can reach
`--api-port` — a repeatable remote crash primitive, not just an internal
correctness bug.

## Fix

Each of the nine string fields now has an accessor method (or already had a
normalizing one) that locks a mutex scoped to its owning config struct, and
the settings write path takes the same lock via a new `newLockedStringField`
constructor. Every hot-path caller was switched from direct field access to
the accessor.

Scalar/bool fields are intentionally untouched: they still race under the Go
memory model, but on the supported architectures a raced word-sized read
can't produce an invalid memory access the way a torn string can, so this
stays scoped to the fields that actually risk a crash.

## Testing

Added `TestLockedStringFields_RaceFree` in
`pkg/config/settings_fields_test.go`, which drives `Field.Set` (the real
`SetMany`/`recompute` write path) against every field's real accessor
concurrently under `-race` — all nine pass clean.

`go build`, `go vet`, and `go test -race ./pkg/...` all pass (aside from a
pre-existing, unrelated failure in `pkg/webui` caused by the frontend not
being built in this checkout).