### PR TITLE
read chunked auth bodies

### DIFF
--- a/pkg/builderapi/epbs/payload_bid.go
+++ b/pkg/builderapi/epbs/payload_bid.go
@@ -165,15 +165,11 @@ func (h *Handler) HandleGetExecutionPayloadBid(w http.ResponseWriter, r *http.Re
 	// Parse and validate SignedRequestAuth from the request body.
 	// Auth is always verified when present; h.cfg.RequireRequestAuth controls whether
 	// absence is an error.
-	var authBody []byte
-	if r.ContentLength > 0 {
-		var readErr error
-		authBody, readErr = io.ReadAll(r.Body)
-		if readErr != nil {
-			log.WithError(readErr).Warn("getExecutionPayloadBid: failed to read request body")
-			writeError(w, http.StatusBadRequest, "failed to read request body")
-			return
-		}
+	authBody, readErr := io.ReadAll(r.Body)
+	if readErr != nil {
+		log.WithError(readErr).Warn("getExecutionPayloadBid: failed to read request body")
+		writeError(w, http.StatusBadRequest, "failed to read request body")
+		return
 	}
 	if len(authBody) > 0 {
 		signedAuth, parseErr := parseSignedRequestAuth(authBody, r.Header.Get("Content-Type"))

--- a/pkg/builderapi/epbs/payload_bid_test.go
+++ b/pkg/builderapi/epbs/payload_bid_test.go
@@ -3,6 +3,7 @@ package epbs
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -556,4 +557,21 @@ func TestHandleGetExecutionPayloadBid_SlotHorizonBound(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestHandleGetExecutionPayloadBid_ReadsChunkedAuthBody(t *testing.T) {
+	env := newPayloadBidTestEnv(t, true)
+	env.cfg.BuilderAPI.RequireRequestAuth = true
+
+	req := newPayloadBidRequest()
+	req.Body = io.NopCloser(strings.NewReader("not json"))
+	req.ContentLength = -1
+	req.TransferEncoding = []string{"chunked"}
+	req.Header.Set("Content-Type", "application/json")
+
+	rec := httptest.NewRecorder()
+	env.handler.HandleGetExecutionPayloadBid(rec, req)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "invalid SignedRequestAuthV1")
 }


### PR DESCRIPTION
reads `SignedRequestAuthV1` bodies regardless of `Request.ContentLength`

Go uses `ContentLength = -1` for valid chunked requests. the existing `ContentLength > 0` guard treated those bodies as absent, causing authenticated bid requests to fail with `401 missing SignedRequestAuthV1`.

the handler now reads `Request.Body` directly and keeps the existing empty-body behavior. adds a regression test covering a chunked request.
