### PR TITLE
update submit beacon blocks route

### DIFF
--- a/pkg/builderapi/epbs/beacon_block.go
+++ b/pkg/builderapi/epbs/beacon_block.go
@@ -19,7 +19,7 @@ import (
 	"github.com/ethpandaops/buildoor/pkg/rpc/beacon"
 )
 
-// HandleSubmitBeaconBlock handles POST /eth/v1/builder/beacon_block.
+// HandleSubmitBeaconBlock handles POST /eth/v1/builder/beacon_blocks.
 //
 // The proposer submits a full post-Gloas SignedBeaconBlock that binds them to
 // the builder's bid. The block is decoded fork-agnostically from either JSON
@@ -37,7 +37,7 @@ import (
 // dialect is disabled, not fully configured, or the chain has not activated
 // Gloas yet.
 func (h *Handler) HandleSubmitBeaconBlock(w http.ResponseWriter, r *http.Request) {
-	log := h.log.WithField("path", "/eth/v1/builder/beacon_block")
+	log := h.log.WithField("path", "/eth/v1/builder/beacon_blocks")
 
 	if !h.enabled.Load() || h.payloadCache == nil {
 		log.Warn("submitBeaconBlock: 503 — builder not fully configured (disabled or payload cache missing)")

--- a/pkg/builderapi/epbs/handler_test.go
+++ b/pkg/builderapi/epbs/handler_test.go
@@ -297,7 +297,7 @@ func signedBeaconBlockJSON(t *testing.T, slot phase0.Slot, blockHash phase0.Hash
 }
 
 func postBeaconBlock(h *Handler, body []byte) *httptest.ResponseRecorder {
-	req := httptest.NewRequest(http.MethodPost, "/eth/v1/builder/beacon_block", bytes.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/eth/v1/builder/beacon_blocks", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 
@@ -364,7 +364,7 @@ func TestHandleSubmitBeaconBlock_ProposalVersion(t *testing.T) {
 	assert.Nil(t, proposal.Heze)
 
 	// Heze via the Eth-Consensus-Version header (same wire schema as Gloas).
-	req := httptest.NewRequest(http.MethodPost, "/eth/v1/builder/beacon_block",
+	req := httptest.NewRequest(http.MethodPost, "/eth/v1/builder/beacon_blocks",
 		bytes.NewReader(signedBeaconBlockJSON(t, slot, blockHash, testBuilderIndex)))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Eth-Consensus-Version", "heze")
@@ -466,7 +466,7 @@ func TestHandleSubmitBeaconBlock_SSZBody(t *testing.T) {
 	body, err := block.MarshalSSZ()
 	require.NoError(t, err)
 
-	req := httptest.NewRequest(http.MethodPost, "/eth/v1/builder/beacon_block", bytes.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/eth/v1/builder/beacon_blocks", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/octet-stream")
 	rec := httptest.NewRecorder()
 

--- a/pkg/builderapi/server.go
+++ b/pkg/builderapi/server.go
@@ -218,7 +218,9 @@ func (s *Server) RegisterRoutes(router *mux.Router) {
 		"/execution_payload_bid/{slot}/{parent_hash}/{parent_root}/{proposer_pubkey}",
 		s.epbs.HandleGetExecutionPayloadBid,
 	).Methods(http.MethodPost)
-	// https://github.com/ethereum/builder-specs/blob/epbs-spec-updates/apis/builder/beacon_block.yaml
+	// https://github.com/ethereum/builder-specs/blob/main/apis/builder/beacon_blocks.yaml
+	builderAPI.HandleFunc("/beacon_blocks", s.epbs.HandleSubmitBeaconBlock).Methods(http.MethodPost)
+	// Keep the former singular route as a compatibility alias.
 	builderAPI.HandleFunc("/beacon_block", s.epbs.HandleSubmitBeaconBlock).Methods(http.MethodPost)
 	// https://github.com/ethereum/builder-specs/blob/epbs-spec-updates/apis/builder/builder_preferences.yaml
 	builderAPI.HandleFunc(

--- a/pkg/builderapi/server.go
+++ b/pkg/builderapi/server.go
@@ -220,8 +220,6 @@ func (s *Server) RegisterRoutes(router *mux.Router) {
 	).Methods(http.MethodPost)
 	// https://github.com/ethereum/builder-specs/blob/main/apis/builder/beacon_blocks.yaml
 	builderAPI.HandleFunc("/beacon_blocks", s.epbs.HandleSubmitBeaconBlock).Methods(http.MethodPost)
-	// Keep the former singular route as a compatibility alias.
-	builderAPI.HandleFunc("/beacon_block", s.epbs.HandleSubmitBeaconBlock).Methods(http.MethodPost)
 	// https://github.com/ethereum/builder-specs/blob/epbs-spec-updates/apis/builder/builder_preferences.yaml
 	builderAPI.HandleFunc(
 		"/builder_preferences/{validator_pubkey}",

--- a/pkg/builderapi/server_test.go
+++ b/pkg/builderapi/server_test.go
@@ -298,18 +298,6 @@ func TestSubmitBlindedBlockV2_MissingContentType(t *testing.T) {
 	assert.Equal(t, http.StatusUnsupportedMediaType, rec.Code)
 }
 
-func TestSubmitBeaconBlockCanonicalRoute(t *testing.T) {
-	cfg := &config.BuilderAPIConfig{}
-	srv := NewServer(cfg, logrus.New(), &mockChainService{}, newServingPlanService(), nil, nil, nil)
-
-	req := httptest.NewRequest(http.MethodPost, "/eth/v1/builder/beacon_blocks", nil)
-	rec := httptest.NewRecorder()
-	srv.Handler().ServeHTTP(rec, req)
-
-	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
-	assert.Contains(t, rec.Body.String(), "builder not ready")
-}
-
 // mockProposalSubmitter records the last SubmitProposal call for tests.
 type mockProposalSubmitter struct {
 	lastProposal *api.VersionedSignedProposal

--- a/pkg/builderapi/server_test.go
+++ b/pkg/builderapi/server_test.go
@@ -298,6 +298,18 @@ func TestSubmitBlindedBlockV2_MissingContentType(t *testing.T) {
 	assert.Equal(t, http.StatusUnsupportedMediaType, rec.Code)
 }
 
+func TestSubmitBeaconBlockCanonicalRoute(t *testing.T) {
+	cfg := &config.BuilderAPIConfig{}
+	srv := NewServer(cfg, logrus.New(), &mockChainService{}, newServingPlanService(), nil, nil, nil)
+
+	req := httptest.NewRequest(http.MethodPost, "/eth/v1/builder/beacon_blocks", nil)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	assert.Contains(t, rec.Body.String(), "builder not ready")
+}
+
 // mockProposalSubmitter records the last SubmitProposal call for tests.
 type mockProposalSubmitter struct {
 	lastProposal *api.VersionedSignedProposal


### PR DESCRIPTION
update signed beacon block endpoint to

```text
POST /eth/v1/builder/beacon_blocks
```

buildoor only registered the obsolete singular path, so clients following current builder-specs received `404 endpoint not found`

also updates handler path labels and existing tests to use the route