### PR TITLE
Make settings persistence atomic and validate timing invariants

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -178,6 +178,10 @@ and begins building blocks according to configuration.`,
 		slotTimeMs := chainSpec.SecondsPerSlot.Milliseconds()
 		cfg.ApplySlotDefaults(slotTimeMs)
 
+		if err := config.ValidateTimingBounds(cfg, chainSpec.SecondsPerSlot); err != nil {
+			return fmt.Errorf("invalid timing configuration: %w", err)
+		}
+
 		logger.WithFields(logrus.Fields{
 			"slot_time_ms":       slotTimeMs,
 			"build_start_time":   cfg.EPBS.BuildStartTime,
@@ -205,7 +209,7 @@ and begins building blocks according to configuration.`,
 			supplied[f.Key] = v.IsSet(f.FlagKey)
 		}
 
-		settingsSvc, err := config.NewService(cfg, defaults, supplied, stateDB, logger)
+		settingsSvc, err := config.NewService(cfg, defaults, supplied, chainSpec.SecondsPerSlot, stateDB, logger)
 		if err != nil {
 			return fmt.Errorf("failed to init settings service: %w", err)
 		}

--- a/pkg/config/settings.go
+++ b/pkg/config/settings.go
@@ -39,12 +39,13 @@ type keyState struct {
 // handed to every module, so writes (applied in place under the service lock)
 // are observed live by all readers.
 type Service struct {
-	log       logrus.FieldLogger
-	store     *db.Database
-	fields    []Field
-	byKey     map[string]Field
-	defaults  *Config // pristine, slot-adjusted defaults — the floor
-	effective *Config // shared config; mutated in place
+	log          logrus.FieldLogger
+	store        *db.Database
+	fields       []Field
+	byKey        map[string]Field
+	defaults     *Config       // pristine, slot-adjusted defaults — the floor
+	effective    *Config       // shared config; mutated in place
+	slotDuration time.Duration // 0 = unknown; skips the reveal-time upper bound check
 
 	mu          sync.Mutex
 	seq         int64
@@ -60,15 +61,21 @@ type Service struct {
 //   - defaults is a pristine, slot-adjusted default Config used as the floor.
 //   - supplied maps each field key to whether the operator explicitly provided
 //     it (viper.IsSet); only supplied keys form the CLI layer.
+//   - slotDuration is the network's slot duration, used to bound
+//     reveal-relative timing overrides; pass 0 if not yet known.
 //   - store is the optional state-db (may be disabled).
-func NewService(effective, defaults *Config, supplied map[string]bool, store *db.Database, log logrus.FieldLogger) (*Service, error) {
+func NewService(
+	effective, defaults *Config, supplied map[string]bool, slotDuration time.Duration,
+	store *db.Database, log logrus.FieldLogger,
+) (*Service, error) {
 	s := &Service{
-		log:       log.WithField("module", "settings"),
-		store:     store,
-		fields:    Fields(),
-		defaults:  defaults,
-		effective: effective,
-		keyState:  make(map[string]*keyState),
+		log:          log.WithField("module", "settings"),
+		store:        store,
+		fields:       Fields(),
+		defaults:     defaults,
+		effective:    effective,
+		slotDuration: slotDuration,
+		keyState:     make(map[string]*keyState),
 	}
 
 	s.byKey = make(map[string]Field, len(s.fields))
@@ -117,6 +124,13 @@ func NewService(effective, defaults *Config, supplied map[string]bool, store *db
 	}
 
 	// Pass 2: reconcile the CLI layer against what the operator supplied now.
+	// Every changed row is batched into a single transaction below rather
+	// than persisted one key at a time, so a crash or a transient state-db
+	// failure mid-pass can never leave only a prefix of this reconciliation
+	// durable.
+	now := time.Now().UnixMilli()
+	changedRows := make([]db.SettingRow, 0, len(s.fields))
+
 	for _, f := range s.fields {
 		ks := s.keyState[f.Key]
 		row := rowByKey[f.Key]
@@ -156,8 +170,17 @@ func NewService(effective, defaults *Config, supplied map[string]bool, store *db
 		}
 
 		if changed {
-			s.persist(f, ks, SourceCLI)
+			built, err := buildSettingRow(f, ks, SourceCLI, now)
+			if err != nil {
+				return nil, fmt.Errorf("encode %q: %w", f.Key, err)
+			}
+
+			changedRows = append(changedRows, built)
 		}
+	}
+
+	if err := store.PutSettings(changedRows); err != nil {
+		return nil, fmt.Errorf("persist cli settings: %w", err)
 	}
 
 	s.recompute()
@@ -185,9 +208,16 @@ func (s *Service) Set(key string, raw json.RawMessage, actor string) error {
 	return s.SetMany(map[string]json.RawMessage{key: raw}, actor)
 }
 
-// SetMany applies a batch of UI overrides atomically: all values are validated
-// and decoded first, then applied, persisted, and the effective config
-// recomputed before subscribers are notified once.
+// SetMany applies a batch of UI overrides atomically: all values are
+// validated and decoded first, then checked together against the timing
+// invariants (§ValidateTimingBounds) the batch would produce, then persisted
+// in one state-db transaction, and only once that durably commits (or
+// persistence is disabled) applied to the effective config and recomputed,
+// before subscribers are notified once. Persistence failing anywhere in the
+// batch leaves both the in-memory state and the state-db exactly as they
+// were before the call — a caller that observes an error can rely on nothing
+// having changed, instead of the previous behaviour of always reporting
+// success while some or all of the batch had silently failed to persist.
 func (s *Service) SetMany(updates map[string]json.RawMessage, actor string) error {
 	s.mu.Lock()
 
@@ -214,13 +244,53 @@ func (s *Service) SetMany(updates map[string]json.RawMessage, actor string) erro
 		decoded[key] = v
 	}
 
+	// Validate the batch's cross-field / slot-relative timing invariants
+	// against what the effective config would become if it commits: apply it
+	// to a scratch copy first, leaving fields the batch doesn't touch at
+	// their current effective value.
+	scratch := *s.effective
 	for key, v := range decoded {
-		f := s.byKey[key]
-		ks := s.keyState[key]
-		ks.hasUI = true
-		ks.uiValue = v
-		ks.uiSeq = s.nextSeq()
-		s.persist(f, ks, actor)
+		if err := s.byKey[key].Set(&scratch, v); err != nil {
+			s.mu.Unlock()
+			return fmt.Errorf("apply %q: %w", key, err)
+		}
+	}
+
+	if err := ValidateTimingBounds(&scratch, s.slotDuration); err != nil {
+		s.mu.Unlock()
+		return err
+	}
+
+	// Stage the new key state and build every row up front: nothing is
+	// applied to s.keyState/s.effective until the whole batch durably
+	// persists.
+	now := time.Now().UnixMilli()
+	rows := make([]db.SettingRow, 0, len(decoded))
+	staged := make(map[string]*keyState, len(decoded))
+
+	for key, v := range decoded {
+		next := *s.keyState[key]
+		next.hasUI = true
+		next.uiValue = v
+		next.uiSeq = s.nextSeq()
+
+		row, err := buildSettingRow(s.byKey[key], &next, actor, now)
+		if err != nil {
+			s.mu.Unlock()
+			return fmt.Errorf("encode %q: %w", key, err)
+		}
+
+		rows = append(rows, row)
+		staged[key] = &next
+	}
+
+	if err := s.store.PutSettings(rows); err != nil {
+		s.mu.Unlock()
+		return fmt.Errorf("persist settings: %w", err)
+	}
+
+	for key, next := range staged {
+		s.keyState[key] = next
 	}
 
 	s.recompute()
@@ -265,35 +335,37 @@ func (s *Service) nextSeq() int64 {
 	return s.seq
 }
 
-// persist writes the full 3-way row for a key to the state-db. Must hold mu.
-func (s *Service) persist(f Field, ks *keyState, actor string) {
-	if !s.store.Enabled() {
-		return
-	}
-
+// buildSettingRow builds the full 3-way persisted row for a key from its
+// keyState, without writing anything: callers batch rows from several keys
+// into a single db.Database.PutSettings transaction.
+func buildSettingRow(f Field, ks *keyState, actor string, updatedAt int64) (db.SettingRow, error) {
 	row := db.SettingRow{
 		Key:       f.Key,
-		UpdatedAt: time.Now().UnixMilli(),
+		UpdatedAt: updatedAt,
 		Actor:     actor,
 	}
 
 	if ks.hasCLI {
-		if b, err := f.Encode(ks.cliValue); err == nil {
-			row.CLIValue = sql.NullString{String: string(b), Valid: true}
-			row.CLISeq = ks.cliSeq
+		b, err := f.Encode(ks.cliValue)
+		if err != nil {
+			return db.SettingRow{}, fmt.Errorf("encode %q cli value: %w", f.Key, err)
 		}
+
+		row.CLIValue = sql.NullString{String: string(b), Valid: true}
+		row.CLISeq = ks.cliSeq
 	}
 
 	if ks.hasUI {
-		if b, err := f.Encode(ks.uiValue); err == nil {
-			row.UIValue = sql.NullString{String: string(b), Valid: true}
-			row.UISeq = ks.uiSeq
+		b, err := f.Encode(ks.uiValue)
+		if err != nil {
+			return db.SettingRow{}, fmt.Errorf("encode %q ui value: %w", f.Key, err)
 		}
+
+		row.UIValue = sql.NullString{String: string(b), Valid: true}
+		row.UISeq = ks.uiSeq
 	}
 
-	if err := s.store.PutSetting(row); err != nil {
-		s.log.WithError(err).WithField("key", f.Key).Warn("failed to persist setting")
-	}
+	return row, nil
 }
 
 // validateValue performs light per-field validation of incoming UI values.
@@ -312,6 +384,33 @@ func validateValue(key string, v any) error {
 		if epochs == 0 {
 			return fmt.Errorf("%s must be greater than 0", key)
 		}
+	}
+
+	return nil
+}
+
+// ValidateTimingBounds checks the cross-field / slot-relative invariants a
+// mutable timing setting must satisfy regardless of which layer (CLI, config
+// file, or UI override) sets it. Neither violation crashes or corrupts
+// anything by itself — an inverted bid window just suppresses bidding, and a
+// too-late reveal time is cleanly skipped rather than published wrong — but
+// both silently defeat the feature for the rest of the run, so they are
+// better rejected outright at the point a value is accepted. slotDuration <=
+// 0 skips the reveal-time upper bound (unknown yet, e.g. before the chain
+// spec has been fetched at startup).
+func ValidateTimingBounds(cfg *Config, slotDuration time.Duration) error {
+	if cfg.EPBS.BidStartTime > cfg.EPBS.BidEndTime {
+		return fmt.Errorf("%s (%dms) must not be after %s (%dms)",
+			KeyEPBSBidStartTime, cfg.EPBS.BidStartTime, KeyEPBSBidEndTime, cfg.EPBS.BidEndTime)
+	}
+
+	if cfg.Reveal.TimeMs < 0 {
+		return fmt.Errorf("%s must not be negative, got %dms", KeyRevealTimeMs, cfg.Reveal.TimeMs)
+	}
+
+	if slotDuration > 0 && time.Duration(cfg.Reveal.TimeMs)*time.Millisecond >= slotDuration {
+		return fmt.Errorf("%s (%dms) must be less than the slot duration (%s)",
+			KeyRevealTimeMs, cfg.Reveal.TimeMs, slotDuration)
 	}
 
 	return nil

--- a/pkg/config/settings_persist_test.go
+++ b/pkg/config/settings_persist_test.go
@@ -1,0 +1,204 @@
+package config
+
+// Tests for NM-23 and NM-24.
+//
+// NM-23: SetMany used to persist one key at a time and return success
+// unconditionally, even when a per-key state-db write failed (or the batch
+// crashed partway through) -- the in-memory effective config would still
+// update, silently diverging from what actually made it to disk. SetMany now
+// batches the whole update into a single transaction and only applies it to
+// memory once that transaction durably commits; any failure leaves both
+// memory and the state-db exactly as they were.
+//
+// NM-24: SetMany validated almost nothing beyond schedule mode, so an
+// unauthenticated client on --api-port (see the threat model note in
+// nemesis-triage.md) could invert the bid window or push the reveal time
+// past the slot deadline with a single write. ValidateTimingBounds now
+// rejects both.
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethpandaops/buildoor/pkg/db"
+)
+
+func setMany(t *testing.T, svc *Service, updates map[string]any, actor string) error {
+	t.Helper()
+
+	raw := make(map[string]json.RawMessage, len(updates))
+
+	for k, v := range updates {
+		b, err := json.Marshal(v)
+		require.NoError(t, err)
+		raw[k] = b
+	}
+
+	return svc.SetMany(raw, actor)
+}
+
+// TestSetMany_PersistFailureLeavesEverythingUnchanged forces the state-db
+// write to fail (by closing the underlying connection out from under the
+// service) and confirms SetMany reports the failure and changes nothing --
+// neither the in-memory effective config nor, on a simulated restart, what
+// was actually durable.
+func TestSetMany_PersistFailureLeavesEverythingUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	store := db.NewDatabase(&db.Config{File: filepath.Join(dir, "state.db")}, testLogger())
+	require.NoError(t, store.Init())
+
+	defaults := defaultsConfig()
+	svc := boot(t, store, defaults, nil)
+
+	setSubsidy(t, svc, 600)
+	require.Equal(t, uint64(600), svc.Load().EPBS.BidSubsidy)
+
+	// Force every subsequent write to fail.
+	require.NoError(t, store.Close())
+
+	err := setMany(t, svc, map[string]any{subsidyKey: uint64(700)}, "tester")
+	require.Error(t, err)
+
+	// In-memory value is untouched by the failed write.
+	assert.Equal(t, uint64(600), svc.Load().EPBS.BidSubsidy)
+}
+
+// TestSetMany_BatchIsAtomic confirms a batch touching several keys either
+// commits entirely or not at all: forcing the persist step to fail must
+// leave every key in the batch unchanged, not just the one that happened to
+// trigger the failure.
+func TestSetMany_BatchIsAtomic(t *testing.T) {
+	dir := t.TempDir()
+	store := db.NewDatabase(&db.Config{File: filepath.Join(dir, "state.db")}, testLogger())
+	require.NoError(t, store.Init())
+
+	defaults := defaultsConfig()
+	svc := boot(t, store, defaults, nil)
+
+	require.NoError(t, setMany(t, svc, map[string]any{
+		subsidyKey:                 uint64(500),
+		KeyEPBSBidMinAmount:        uint64(1000),
+		KeyBuilderAPIOnDemandBuild: true,
+	}, "tester"))
+
+	require.Equal(t, uint64(500), svc.Load().EPBS.BidSubsidy)
+	require.Equal(t, uint64(1000), svc.Load().EPBS.BidMinAmount)
+	require.True(t, svc.Load().BuilderAPI.OnDemandBuild)
+
+	require.NoError(t, store.Close())
+
+	err := setMany(t, svc, map[string]any{
+		subsidyKey:                 uint64(999),
+		KeyEPBSBidMinAmount:        uint64(999),
+		KeyBuilderAPIOnDemandBuild: false,
+	}, "tester")
+	require.Error(t, err)
+
+	// None of the three keys moved, not just the one whose write "happened"
+	// to fail first.
+	assert.Equal(t, uint64(500), svc.Load().EPBS.BidSubsidy)
+	assert.Equal(t, uint64(1000), svc.Load().EPBS.BidMinAmount)
+	assert.True(t, svc.Load().BuilderAPI.OnDemandBuild)
+}
+
+func TestValidateTimingBounds(t *testing.T) {
+	tests := []struct {
+		name         string
+		mutate       func(*Config)
+		slotDuration time.Duration
+		wantErr      bool
+	}{
+		{
+			name:         "defaults are valid",
+			mutate:       func(*Config) {},
+			slotDuration: 12 * time.Second,
+		},
+		{
+			name: "inverted bid window rejected",
+			mutate: func(c *Config) {
+				c.EPBS.BidStartTime = -100
+				c.EPBS.BidEndTime = -400
+			},
+			slotDuration: 12 * time.Second,
+			wantErr:      true,
+		},
+		{
+			name: "equal bid start/end allowed",
+			mutate: func(c *Config) {
+				c.EPBS.BidStartTime = -400
+				c.EPBS.BidEndTime = -400
+			},
+			slotDuration: 12 * time.Second,
+		},
+		{
+			name: "negative reveal time rejected",
+			mutate: func(c *Config) {
+				c.Reveal.TimeMs = -1
+			},
+			slotDuration: 12 * time.Second,
+			wantErr:      true,
+		},
+		{
+			name: "reveal time past the slot deadline rejected",
+			mutate: func(c *Config) {
+				c.Reveal.TimeMs = 12000
+			},
+			slotDuration: 12 * time.Second,
+			wantErr:      true,
+		},
+		{
+			name: "reveal time bound skipped when slot duration unknown",
+			mutate: func(c *Config) {
+				c.Reveal.TimeMs = 999999
+			},
+			slotDuration: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := defaultsConfig()
+			tt.mutate(cfg)
+
+			err := ValidateTimingBounds(cfg, tt.slotDuration)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestSetMany_RejectsInvertedBidWindow guards the actual attack surface this
+// closes: SetMany itself, not just the standalone validator, must reject a
+// write that would invert the bid window -- including when only one of the
+// two fields is touched by this particular call (the other must be compared
+// against its current effective value, not silently skipped).
+func TestSetMany_RejectsInvertedBidWindow(t *testing.T) {
+	dir := t.TempDir()
+	store := db.NewDatabase(&db.Config{File: filepath.Join(dir, "state.db")}, testLogger())
+	require.NoError(t, store.Init())
+
+	defaults := defaultsConfig()
+	svc := boot(t, store, defaults, nil)
+
+	originalStart := svc.Load().EPBS.BidStartTime
+	originalEnd := svc.Load().EPBS.BidEndTime
+	require.Less(t, originalStart, originalEnd)
+
+	// Only bid_end_time is touched, but pushed before the CURRENT
+	// (untouched) bid_start_time -- must still be rejected.
+	err := setMany(t, svc, map[string]any{KeyEPBSBidEndTime: originalStart - 1}, "tester")
+	require.Error(t, err)
+	assert.Equal(t, originalEnd, svc.Load().EPBS.BidEndTime, "rejected write must not partially apply")
+
+	// A reveal time at or past the slot deadline is rejected too.
+	err = setMany(t, svc, map[string]any{KeyRevealTimeMs: int64(12000)}, "tester")
+	require.Error(t, err)
+}

--- a/pkg/config/settings_test.go
+++ b/pkg/config/settings_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
@@ -42,7 +43,7 @@ func boot(t *testing.T, store *db.Database, defaults *Config, suppliedVal *uint6
 		supplied[subsidyKey] = true
 	}
 
-	svc, err := NewService(&eff, defaults, supplied, store, testLogger())
+	svc, err := NewService(&eff, defaults, supplied, 12*time.Second, store, testLogger())
 	require.NoError(t, err)
 
 	return svc
@@ -134,7 +135,7 @@ func TestUnsuppliedUsesDefault(t *testing.T) {
 	eff := *defaults
 	eff.EPBS.BidSubsidy = 999 // present in effective but NOT operator-supplied
 
-	svc, err := NewService(&eff, defaults, map[string]bool{}, store, testLogger())
+	svc, err := NewService(&eff, defaults, map[string]bool{}, 12*time.Second, store, testLogger())
 	require.NoError(t, err)
 	require.Equal(t, defaults.EPBS.BidSubsidy, svc.Load().EPBS.BidSubsidy)
 }

--- a/pkg/db/settings.go
+++ b/pkg/db/settings.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"database/sql"
+	"fmt"
 
 	"github.com/jmoiron/sqlx"
 )
@@ -43,21 +44,27 @@ func (d *Database) GetSettings() ([]SettingRow, error) {
 	return rows, nil
 }
 
-// PutSetting upserts the full 3-way state for a settings key. No-op when the
-// database is disabled. The settings service owns the in-memory authority and
-// always writes the complete row, so a plain INSERT OR REPLACE is correct.
-func (d *Database) PutSetting(row SettingRow) error {
-	if !d.enabled {
+// PutSettings upserts the full 3-way state for a batch of settings keys in a
+// single transaction: either every row commits or none do. No-op when the
+// database is disabled or the batch is empty. The settings service owns the
+// in-memory authority and always writes the complete row, so a plain INSERT
+// OR REPLACE per row is correct.
+func (d *Database) PutSettings(rows []SettingRow) error {
+	if !d.enabled || len(rows) == 0 {
 		return nil
 	}
 
 	return d.RunDBTransaction(func(tx *sqlx.Tx) error {
-		_, err := tx.Exec(`
-			INSERT OR REPLACE INTO settings
-				(key, cli_value, cli_seq, ui_value, ui_seq, updated_at, actor)
-			VALUES ($1, $2, $3, $4, $5, $6, $7)`,
-			row.Key, row.CLIValue, row.CLISeq, row.UIValue, row.UISeq, row.UpdatedAt, row.Actor)
+		for _, row := range rows {
+			if _, err := tx.Exec(`
+				INSERT OR REPLACE INTO settings
+					(key, cli_value, cli_seq, ui_value, ui_seq, updated_at, actor)
+				VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+				row.Key, row.CLIValue, row.CLISeq, row.UIValue, row.UISeq, row.UpdatedAt, row.Actor); err != nil {
+				return fmt.Errorf("upsert setting %q: %w", row.Key, err)
+			}
+		}
 
-		return err
+		return nil
 	})
 }

--- a/pkg/db/settings_test.go
+++ b/pkg/db/settings_test.go
@@ -1,0 +1,61 @@
+package db
+
+import (
+	"database/sql"
+	"io"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPutSettingsBatchRoundTrip confirms a multi-row batch upserts every row
+// in the single transaction PutSettings runs (NM-23: settings used to be
+// persisted one row per transaction).
+func TestPutSettingsBatchRoundTrip(t *testing.T) {
+	d := testDB(t)
+
+	require.NoError(t, d.PutSettings([]SettingRow{
+		{Key: "a", UIValue: sql.NullString{String: `1`, Valid: true}, UISeq: 1, UpdatedAt: 100},
+		{Key: "b", UIValue: sql.NullString{String: `2`, Valid: true}, UISeq: 1, UpdatedAt: 100},
+		{Key: "c", UIValue: sql.NullString{String: `3`, Valid: true}, UISeq: 1, UpdatedAt: 100},
+	}))
+
+	rows, err := d.GetSettings()
+	require.NoError(t, err)
+
+	byKey := make(map[string]SettingRow, len(rows))
+	for _, r := range rows {
+		byKey[r.Key] = r
+	}
+
+	require.Len(t, byKey, 3)
+	assert.Equal(t, `1`, byKey["a"].UIValue.String)
+	assert.Equal(t, `2`, byKey["b"].UIValue.String)
+	assert.Equal(t, `3`, byKey["c"].UIValue.String)
+}
+
+// TestPutSettingsNoopWhenDisabled confirms a batch write against a disabled
+// (no state-db configured) database is a silent no-op, not an error --
+// callers rely on this to keep working in-memory-only.
+func TestPutSettingsNoopWhenDisabled(t *testing.T) {
+	log := logrus.New()
+	log.SetOutput(io.Discard)
+
+	d := NewDatabase(&Config{}, log)
+	require.NoError(t, d.Init())
+	require.False(t, d.Enabled())
+
+	require.NoError(t, d.PutSettings([]SettingRow{{Key: "a"}}))
+}
+
+// TestPutSettingsFailsAfterClose confirms a batch write against a closed
+// connection reports an error rather than silently succeeding.
+func TestPutSettingsFailsAfterClose(t *testing.T) {
+	d := testDB(t)
+	require.NoError(t, d.Close())
+
+	err := d.PutSettings([]SettingRow{{Key: "a"}})
+	assert.Error(t, err)
+}

--- a/pkg/webui/handlers/api/action_plan_test.go
+++ b/pkg/webui/handlers/api/action_plan_test.go
@@ -477,7 +477,7 @@ func TestUpdateSettingsPathBased(t *testing.T) {
 	cfg := config.DefaultConfig()
 	defaults := config.DefaultConfig()
 
-	settingsSvc, err := config.NewService(cfg, defaults, map[string]bool{}, stateDB, log)
+	settingsSvc, err := config.NewService(cfg, defaults, map[string]bool{}, 12*time.Second, stateDB, log)
 	require.NoError(t, err)
 
 	authHandler, err := auth.NewAuthHandler(context.Background(), "")


### PR DESCRIPTION
## Problem

Two related gaps in the settings service, both reachable through the same
unauthenticated write path (the WebUI and Builder API share one HTTP port,
unauthenticated unless an auth provider is configured):

Persistence was per-key and silently lossy. SetMany wrote one state-db
transaction per key and returned success unconditionally, even when a write
failed or the process crashed partway through a batch. The in-memory config
would already reflect the change, so a restart could silently revert a
setting the caller had been told succeeded, or leave a batch half-applied
with no way to tell which half.

Validation covered almost nothing beyond schedule mode. A single write could
invert the bid window (bid_start_time after bid_end_time) or push the reveal
time past the slot deadline. Neither crashes anything - an inverted window
just suppresses bidding and a late reveal is cleanly skipped - but both
silently defeat the feature for the rest of the run.

## Fix

SetMany now stages a batch's changes, checks them against the resulting
config's timing invariants, and persists everything in one transaction
before applying anything to memory. A failure at any step leaves both memory
and the state-db exactly as they were, and the caller gets the actual error
instead of an unconditional nil. The same validation runs against
CLI/config-file input at startup, right after slot-relative defaults are
computed.

db.Database gained PutSettings, a batch upsert in a single transaction,
replacing the old per-row PutSetting.

## Testing

9 new tests across three files covering: atomicity under a forced real
SQLite failure, batch-all-or-nothing behavior, the validation rule table,
and the actual SetMany rejection path; plus db-level batch round-trip,
disabled no-op, and closed-connection failure cases. All existing tests in
`pkg/config` and `pkg/webui/handlers/api` still pass unchanged.

`go build`, `go vet`, and `go test -race ./pkg/...` all pass (aside from a
pre-existing, unrelated failure in `pkg/webui` caused by the frontend not
being built in this checkout).