### PR TITLE
fix(lifecycle): read the builder queue fee from the contract

### DIFF
--- a/pkg/lifecycle/contract.go
+++ b/pkg/lifecycle/contract.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -38,10 +39,14 @@ const (
 	// feeUpdateFraction is *_REQUEST_FEE_UPDATE_FRACTION (17): the fake-exponential
 	// denominator controlling how steeply the queue fee grows with excess requests.
 	feeUpdateFraction = 17
-	// queueFeeHeadroom prices the fee a few queue slots ahead of the currently
-	// observed excess, so the request still clears if other requests land in the
+	// queueFeeHeadroom prices the fee a few queue slots ahead of the contract's
+	// current quote, so the request still clears if other requests land in the
 	// same block(s) before ours is included. Mirrors dora's "add extra fee".
 	queueFeeHeadroom = 3
+	// headroomScale is the fixed-point denominator used to apply queueFeeHeadroom
+	// as a multiplier. The fee grows as e^(excess/feeUpdateFraction), so pricing N
+	// slots ahead scales the quote by e^(N/feeUpdateFraction).
+	headroomScale = 1_000_000
 
 	// builderWithdrawalPrefix is the withdrawal-credential prefix for builder
 	// deposits submitted via the EIP-8282 builder deposit contract. Must be
@@ -60,10 +65,12 @@ const (
 // accepting requests, so callers must wait rather than submit.
 var excessInhibitor = new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 256), big.NewInt(1))
 
-// contractReader reads contract storage and code; satisfied by *execution.Client.
+// contractReader reads contract storage and code and performs read-only calls;
+// satisfied by *execution.Client.
 type contractReader interface {
 	GetStorageAt(ctx context.Context, account common.Address, slot common.Hash) ([]byte, error)
 	GetCode(ctx context.Context, account common.Address) ([]byte, error)
+	CallContract(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error)
 }
 
 // BuildBuilderDepositCalldata builds the 184-byte builder deposit request calldata:
@@ -146,9 +153,53 @@ func ReadQueueFee(
 		return nil, false, nil
 	}
 
-	numerator := new(big.Int).Add(excess, big.NewInt(queueFeeHeadroom))
+	quote, err := readContractFee(ctx, reader, contract)
+	if err != nil {
+		return nil, false, err
+	}
 
-	return fakeExponential(big.NewInt(minRequestFee), numerator, big.NewInt(feeUpdateFraction)), true, nil
+	return applyQueueFeeHeadroom(quote), true, nil
+}
+
+// readContractFee asks the predeploy for its current per-request fee by calling it
+// with empty calldata, per the EIP-7002 fee interface.
+//
+// The quote must come from the contract rather than being recomputed from the
+// excess counter in slot 0: excess is only folded in by the end-of-block system
+// call, so requests already queued in the current block are invisible to a storage
+// read. Deriving the fee from slot 0 alone therefore returns the minimum fee while
+// the contract charges for the full queue, and every request reverts on an
+// insufficient fee.
+func readContractFee(ctx context.Context, reader contractReader, contract common.Address) (*big.Int, error) {
+	out, err := reader.CallContract(ctx, ethereum.CallMsg{To: &contract}, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read queue fee: %w", err)
+	}
+
+	if len(out) == 0 || len(out) > 32 {
+		return nil, fmt.Errorf("%w: got %d bytes", ErrUnexpectedFeeResponse, len(out))
+	}
+
+	return new(big.Int).SetBytes(out), nil
+}
+
+// applyQueueFeeHeadroom scales a fee quote queueFeeHeadroom queue slots ahead and
+// never returns less than the minimum request fee.
+func applyQueueFeeHeadroom(quote *big.Int) *big.Int {
+	scale := fakeExponential(
+		big.NewInt(headroomScale),
+		big.NewInt(queueFeeHeadroom),
+		big.NewInt(feeUpdateFraction),
+	)
+
+	fee := new(big.Int).Mul(quote, scale)
+	fee.Div(fee, big.NewInt(headroomScale))
+
+	if fee.Cmp(big.NewInt(minRequestFee)) < 0 {
+		return big.NewInt(minRequestFee)
+	}
+
+	return fee
 }
 
 // fakeExponential approximates factor * e^(numerator/denominator) using integer

--- a/pkg/lifecycle/contract_test.go
+++ b/pkg/lifecycle/contract_test.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -123,11 +124,21 @@ func TestWithdrawalCredentials(t *testing.T) {
 }
 
 // fakeStorageReader returns a fixed 32-byte slot value and non-empty code
-// unless noCode is set.
+// unless noCode is set. callResult is what the queue fee getter answers with.
 type fakeStorageReader struct {
-	value  []byte
-	err    error
-	noCode bool
+	value      []byte
+	err        error
+	noCode     bool
+	callResult []byte
+	callErr    error
+}
+
+func (f fakeStorageReader) CallContract(_ context.Context, _ ethereum.CallMsg, _ *big.Int) ([]byte, error) {
+	if f.callErr != nil {
+		return nil, f.callErr
+	}
+
+	return f.callResult, nil
 }
 
 func (f fakeStorageReader) GetStorageAt(_ context.Context, _ common.Address, _ common.Hash) ([]byte, error) {
@@ -158,13 +169,14 @@ func TestReadQueueFee(t *testing.T) {
 	assert.False(t, active, "inhibitor means contract not active")
 	assert.Nil(t, fee)
 
-	// Active contract with excess=0 -> fee priced queueFeeHeadroom slots ahead.
-	fee, active, err = ReadQueueFee(ctx, fakeStorageReader{value: slotBytes(big.NewInt(0))}, BuilderDepositContractAddress)
+	// Active contract -> the contract's quote, priced queueFeeHeadroom slots ahead.
+	fee, active, err = ReadQueueFee(ctx, fakeStorageReader{
+		value:      slotBytes(big.NewInt(0)),
+		callResult: slotBytes(big.NewInt(64)),
+	}, BuilderDepositContractAddress)
 	require.NoError(t, err)
 	assert.True(t, active)
-
-	want := fakeExponential(big.NewInt(minRequestFee), big.NewInt(queueFeeHeadroom), big.NewInt(feeUpdateFraction))
-	assert.Equal(t, want.String(), fee.String(), "fee includes headroom over excess")
+	assert.Equal(t, "76", fee.String(), "fee is the contract quote plus headroom")
 
 	// No code at the address -> ErrContractNotDeployed, never "active": an empty
 	// account reads slot 0 as zero, which must not be mistaken for an empty queue.
@@ -172,4 +184,46 @@ func TestReadQueueFee(t *testing.T) {
 	require.ErrorIs(t, err, ErrContractNotDeployed)
 	assert.False(t, active)
 	assert.Nil(t, fee)
+}
+
+// TestReadQueueFeeUsesContractQuote is a regression test for builder deposits
+// reverting on an insufficient fee.
+//
+// The excess counter in slot 0 is only folded in by the end-of-block system call,
+// so while requests are queued in the current block it still reads zero even
+// though the contract already charges for the full queue. Deriving the fee from
+// slot 0 produced the 1 wei minimum against a real fee of 64 wei, and every
+// deposit reverted.
+func TestReadQueueFeeUsesContractQuote(t *testing.T) {
+	ctx := context.Background()
+
+	reader := fakeStorageReader{
+		value:      slotBytes(big.NewInt(0)),  // excess not yet updated
+		callResult: slotBytes(big.NewInt(64)), // what the contract actually charges
+	}
+
+	fee, active, err := ReadQueueFee(ctx, reader, BuilderDepositContractAddress)
+	require.NoError(t, err)
+	assert.True(t, active)
+	assert.GreaterOrEqual(t, fee.Int64(), int64(64), "fee must cover the contract quote")
+	assert.NotEqual(t, int64(minRequestFee), fee.Int64(), "must not fall back to the minimum fee")
+}
+
+func TestReadQueueFeeRejectsMalformedQuote(t *testing.T) {
+	ctx := context.Background()
+
+	for name, result := range map[string][]byte{
+		"empty":    {},
+		"oversize": make([]byte, 33),
+	} {
+		t.Run(name, func(t *testing.T) {
+			fee, active, err := ReadQueueFee(ctx, fakeStorageReader{
+				value:      slotBytes(big.NewInt(0)),
+				callResult: result,
+			}, BuilderDepositContractAddress)
+			require.ErrorIs(t, err, ErrUnexpectedFeeResponse)
+			assert.False(t, active)
+			assert.Nil(t, fee)
+		})
+	}
 }

--- a/pkg/lifecycle/deposit.go
+++ b/pkg/lifecycle/deposit.go
@@ -31,6 +31,10 @@ var ErrContractNotActive = errors.New("builder deposit contract not active yet")
 // addresses than this build expects.
 var ErrContractNotDeployed = errors.New("builder system contract not deployed")
 
+// ErrUnexpectedFeeResponse is returned when a builder system contract's queue fee
+// getter answers with something other than a single 32-byte word.
+var ErrUnexpectedFeeResponse = errors.New("unexpected queue fee response")
+
 // ErrBuilderExited is returned when a deposit/top-up targets a builder whose exit has
 // been initiated. Exited builders can never be reactivated: the deposit would only top
 // up the exited registry entry and be withdrawn back to the wallet by the sweep. The

--- a/pkg/rpc/execution/client.go
+++ b/pkg/rpc/execution/client.go
@@ -223,6 +223,17 @@ func (c *Client) HeaderByNumber(ctx context.Context, number *big.Int) (*types.He
 	return header, nil
 }
 
+// CallContract executes a read-only message call against a contract. A nil
+// blockNumber selects the latest block.
+func (c *Client) CallContract(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+	result, err := c.ethClient.CallContract(ctx, msg, blockNumber)
+	if err != nil {
+		return nil, fmt.Errorf("failed to call contract: %w", err)
+	}
+
+	return result, nil
+}
+
 // EstimateGas estimates gas for a transaction.
 func (c *Client) EstimateGas(ctx context.Context, msg ethereum.CallMsg) (uint64, error) {
 	gas, err := c.ethClient.EstimateGas(ctx, msg)


### PR DESCRIPTION
## Problem

Builder deposits and top-ups revert with an insufficient fee whenever the request queue is busy.

`ReadQueueFee` derived the fee from the predeploy's excess counter in storage slot 0. That counter is only folded in by the end-of-block system call, so requests already queued in the current block are invisible to a storage read.

Observed on a glamsterdam-devnet-8 node, against `0x0000bFF46984e3725691FA540a8C7589300D8282`:

```
slot 0 (excess) = 0        slot 2 (queue head) = 0
slot 1 (count)  = 79       slot 3 (queue tail) = 79

fake_exponential(1, 0 + 3, 17) =  1 wei   <- what we paid
eth_call (empty calldata)      = 64 wei   <- what the contract charges
```

The deposit tx therefore sent `50 ETH + 1 wei` where `50 ETH + 64 wei` was required, and reverted early (29,268 gas, empty revert data). Every automated deposit and top-up fails the same way while the queue is non-empty.

`DepositMaxFeeGwei` only *delays* a request when the fee is too high (`resolveDepositFee` → `ErrDepositFeeTooHigh`); it never raises what gets paid, so there is no configuration workaround.

## Fix

Ask the contract for its current fee by calling it with empty calldata, per the EIP-7002 fee interface. That quote accounts for the full queue and is authoritative regardless of how the predeploy folds `count` into `excess`.

- Slot 0 is still read, but only to detect the pre-fork excess inhibitor.
- `queueFeeHeadroom` keeps its meaning of pricing N queue slots ahead. Since the fee grows as `e^(excess/feeUpdateFraction)`, it is now applied as a multiplier on the quote (`e^(3/17)` ≈ 1.193, so a 64 wei quote is paid as 76 wei).
- A malformed getter response is rejected with `ErrUnexpectedFeeResponse` rather than silently becoming a bogus fee.
- Adds `CallContract` to `execution.Client`.

## Tests

`TestReadQueueFeeUsesContractQuote` is a regression test for exactly this case: excess reads 0 while the contract quotes 64, and it asserts the fee covers the quote instead of collapsing to the 1 wei minimum. `TestReadQueueFeeRejectsMalformedQuote` covers empty and oversize responses.

`go build ./...`, `go vet ./...` and `go test ./...` all pass.
