### PR TITLE
feat(webui): link the brand logo to the overview UI when configured

### DIFF
--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -37,7 +37,7 @@ type Config struct {
 	APIPort           int               `yaml:"api_port" json:"api_port"`                       // Optional, 0 = disabled
 	AuthProviderURL   string            `yaml:"auth_provider_url" json:"auth_provider_url"`     // Optional: authenticatoor URL; when set, API requests must carry a JWT verified against the authenticatoor's JWKS. When empty, the API is unauthenticated.
 	InjectHeadHTML    string            `yaml:"inject_head_html" json:"inject_head_html"`       // Optional: raw HTML snippet (e.g. analytics tags) injected into <head> of the served SPA. Falls back to BUILDOOR_INJECT_HEAD_HTML env var when empty.
-	OverviewURL       string            `yaml:"overview_url" json:"overview_url"`               // Optional: URL of the multi-instance overview UI. When set, the dashboard renders an "Overview" entry in the top nav so operators get consistent navigation across instances.
+	OverviewURL       string            `yaml:"overview_url" json:"overview_url"`               // Optional: URL of the multi-instance overview UI. When set, the dashboard renders an "Overview" entry in the top nav and the brand logo links back to the overview, so operators get consistent navigation across instances.
 	LifecycleEnabled  bool              `yaml:"lifecycle_enabled" json:"lifecycle_enabled"`
 	EPBSEnabled       bool              `yaml:"epbs_enabled" json:"epbs_enabled"`               // Initial enabled state for ePBS (service available if Gloas fork is scheduled)
 	BuilderAPIEnabled bool              `yaml:"builder_api_enabled" json:"builder_api_enabled"` // Initial enabled state for Builder API

--- a/pkg/webui/src/components/Header.tsx
+++ b/pkg/webui/src/components/Header.tsx
@@ -3,12 +3,18 @@ import { BrandHeader } from './BrandHeader';
 import { HeaderNav } from './HeaderNav';
 import { UserDisplay } from './UserDisplay';
 import { setView } from '../stores/viewStore';
+import { getRuntimeConfig } from '../utils/runtimeConfig';
 
 export const Header: React.FC = () => {
+  // When an overview UI is configured, the brand link leaves this instance
+  // for the multi-instance overview; otherwise it stays a dashboard shortcut.
+  const { overviewURL } = getRuntimeConfig();
+
   return (
     <BrandHeader
       title="Buildoor"
-      onBrandClick={() => setView('dashboard')}
+      brandHref={overviewURL || '/'}
+      onBrandClick={overviewURL ? undefined : () => setView('dashboard')}
       navItems={<HeaderNav />}
       endContent={<UserDisplay />}
     />


### PR DESCRIPTION
## Summary

When `overview_url` is configured (already injected into the SPA as runtime config and powering the "Overview" nav button), clicking the top-left brand logo/title on an individual builder instance now navigates to the multi-instance overview page.

Instances without `overview_url` keep the previous behavior: the brand acts as a shortcut to the local Dashboard view.

Also updates the `overview_url` field comment in `pkg/config/types.go` to document the new behavior.

## Testing

- `npm run build` in `pkg/webui` compiles cleanly
- Verified the devnet-8 instances already inject `overviewURL`, so this needs no deployment config changes — just an image rebuild/redeploy