### PR TITLE
feat(webui): link the brand logo to the overview UI when configured + ci bump

### DIFF
--- a/.github/workflows/_shared-build.yaml
+++ b/.github/workflows/_shared-build.yaml
@@ -118,7 +118,7 @@ jobs:
     - name: Set up go
       uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:
-        go-version: 1.25.x
+        go-version: 1.26.x
 
     # setup project dependencies
     - name: Get dependencies
@@ -163,7 +163,7 @@ jobs:
     - name: Set up go
       uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:
-        go-version: 1.25.x
+        go-version: 1.26.x
 
     # setup project dependencies
     - name: Get dependencies
@@ -206,7 +206,7 @@ jobs:
     - name: Set up go
       uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:
-        go-version: 1.25.x
+        go-version: 1.26.x
 
     # setup project dependencies
     - name: Get dependencies
@@ -248,7 +248,7 @@ jobs:
     - name: Set up go
       uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:
-        go-version: 1.25.x
+        go-version: 1.26.x
 
     # setup project dependencies
     - name: Get dependencies

--- a/.github/workflows/_shared-check.yaml
+++ b/.github/workflows/_shared-check.yaml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up go
       uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:
-        go-version: 1.25.x
+        go-version: 1.26.x
     - name: Set up node
       uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:

--- a/.github/workflows/_shared-e2e.yaml
+++ b/.github/workflows/_shared-e2e.yaml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up go
       uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:
-        go-version: 1.25.x
+        go-version: 1.26.x
     - name: Set up node
       uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY pkg/webui/src/ src/
 RUN make build
 
 # ── Stage 2: Build Go binary (CGO required for herumi BLS) ──────
-FROM golang:1.25-bookworm AS builder
+FROM golang:1.26-bookworm AS builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gcc libc6-dev \

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -37,7 +37,7 @@ type Config struct {
 	APIPort           int               `yaml:"api_port" json:"api_port"`                       // Optional, 0 = disabled
 	AuthProviderURL   string            `yaml:"auth_provider_url" json:"auth_provider_url"`     // Optional: authenticatoor URL; when set, API requests must carry a JWT verified against the authenticatoor's JWKS. When empty, the API is unauthenticated.
 	InjectHeadHTML    string            `yaml:"inject_head_html" json:"inject_head_html"`       // Optional: raw HTML snippet (e.g. analytics tags) injected into <head> of the served SPA. Falls back to BUILDOOR_INJECT_HEAD_HTML env var when empty.
-	OverviewURL       string            `yaml:"overview_url" json:"overview_url"`               // Optional: URL of the multi-instance overview UI. When set, the dashboard renders an "Overview" entry in the top nav so operators get consistent navigation across instances.
+	OverviewURL       string            `yaml:"overview_url" json:"overview_url"`               // Optional: URL of the multi-instance overview UI. When set, the dashboard renders an "Overview" entry in the top nav and the brand logo links back to the overview, so operators get consistent navigation across instances.
 	LifecycleEnabled  bool              `yaml:"lifecycle_enabled" json:"lifecycle_enabled"`
 	EPBSEnabled       bool              `yaml:"epbs_enabled" json:"epbs_enabled"`               // Initial enabled state for ePBS (service available if Gloas fork is scheduled)
 	BuilderAPIEnabled bool              `yaml:"builder_api_enabled" json:"builder_api_enabled"` // Initial enabled state for Builder API

--- a/pkg/webui/src/components/Header.tsx
+++ b/pkg/webui/src/components/Header.tsx
@@ -3,12 +3,18 @@ import { BrandHeader } from './BrandHeader';
 import { HeaderNav } from './HeaderNav';
 import { UserDisplay } from './UserDisplay';
 import { setView } from '../stores/viewStore';
+import { getRuntimeConfig } from '../utils/runtimeConfig';
 
 export const Header: React.FC = () => {
+  // When an overview UI is configured, the brand link leaves this instance
+  // for the multi-instance overview; otherwise it stays a dashboard shortcut.
+  const { overviewURL } = getRuntimeConfig();
+
   return (
     <BrandHeader
       title="Buildoor"
-      onBrandClick={() => setView('dashboard')}
+      brandHref={overviewURL || '/'}
+      onBrandClick={overviewURL ? undefined : () => setView('dashboard')}
       navItems={<HeaderNav />}
       endContent={<UserDisplay />}
     />


### PR DESCRIPTION
## Why

CI's `Check PR` job started failing on every PR yesterday: staticcheck 2026.2 (v0.8.0, released 2026-08-20) requires Go >= 1.26, but the workflows install it with `@latest` while running Go 1.25 with `GOTOOLCHAIN=local`:

```
go: honnef.co/go/tools/cmd/staticcheck@latest: honnef.co/go/tools@v0.8.0 requires go >= 1.26.0 (running go 1.25.13; GOTOOLCHAIN=local)
```

## What

Bump Go 1.25 → 1.26 everywhere it's declared:
- `_shared-check.yaml`, `_shared-e2e.yaml`, `_shared-build.yaml` (`go-version: 1.26.x`)
- `Dockerfile` builder image (`golang:1.26-bookworm`)

Verified locally: staticcheck v0.8.0 passes cleanly over the repo, and the `golang:1.26-bookworm` image tag exists on Docker Hub. `go.mod` stays at `go 1.25.7` — a newer toolchain builds it fine.